### PR TITLE
feat: auto-extract and inject OpenSCENARIO file references into manifest

### DIFF
--- a/asset_extraction/main.py
+++ b/asset_extraction/main.py
@@ -463,6 +463,8 @@ def main():
     if extractor_json.exists():
         auto_refs = _refs_from_extractor(extractor_json)
         if auto_refs:
+            if refs is None:
+                refs = []
             refs.extend(auto_refs)
 
     if refs and manifest_path.exists():

--- a/asset_extraction/main.py
+++ b/asset_extraction/main.py
@@ -174,6 +174,50 @@ def execute_script(script_config: dict, asset_file: Path, output_dir: Path):
     )
 
 
+def _refs_from_extractor(extractor_json: Path) -> list[dict]:
+    """Build input-manifest-style reference dicts from extractor-discovered
+    file references (``scenario:fileReferences``)."""
+    try:
+        with extractor_json.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return []
+
+    file_refs = data.get("scenario:fileReferences", [])
+    if not file_refs:
+        return []
+
+    mime_map = {
+        ".xodr": "application/xml",
+        ".xosc": "application/xml",
+        ".xml": "application/xml",
+        ".gltf": "model/gltf+json",
+        ".glb": "model/gltf-binary",
+        ".fbx": "application/octet-stream",
+        ".obj": "text/plain",
+    }
+
+    refs: list[dict] = []
+    for entry in file_refs:
+        rel_path = entry.get("relativePath", entry.get("path", ""))
+        if not rel_path:
+            continue
+        suffix = Path(rel_path).suffix.lower()
+        refs.append(
+            {
+                "@type": "Link",
+                "hasCategory": {"@id": "envited-x:isSimulationData"},
+                "hasAccessRole": {"@id": "envited-x:isPublic"},
+                "hasFileMetadata": {
+                    "@type": "FileMetadata",
+                    "filePath": rel_path,
+                    "mimeType": mime_map.get(suffix, "application/octet-stream"),
+                },
+            }
+        )
+    return refs
+
+
 def _format_reference(ref: dict) -> dict:
     """Format a referenced artifact link from input manifest JSON-LD
     to match the output manifest format used by jsonLD_creator."""
@@ -411,6 +455,16 @@ def main():
     # inject referenced artifacts from input manifest into output manifest
     refs = load_referenced_artifacts(uploaded_file)
     manifest_path = output_sub_dir / "manifest.json"
+
+    # Auto-discover file references from extractor JSON (for OpenSCENARIO
+    # files the extractor records map, catalog, scene-graph, and controller
+    # references).  These are merged with any user-provided references.
+    extractor_json = output_sub_dir / "temp" / f"{asset_name}_extractor.json"
+    if extractor_json.exists():
+        auto_refs = _refs_from_extractor(extractor_json)
+        if auto_refs:
+            refs.extend(auto_refs)
+
     if refs and manifest_path.exists():
         with manifest_path.open("r", encoding="utf-8") as f:
             manifest = json.load(f)

--- a/asset_extraction/main.py
+++ b/asset_extraction/main.py
@@ -262,9 +262,10 @@ def _refs_from_extractor(
             continue
 
         # Determine access role: local paths inherit from parent asset,
-        # external references (DIDs, URLs) get isPublic.
+        # external references (DIDs, URLs) get isRegistered since their
+        # actual access level is governed by the referenced asset itself.
         if rel_path.startswith(("did:", "http://", "https://")):
-            role = "envited-x:isPublic"
+            role = "envited-x:isRegistered"
         else:
             role = asset_access_role
 

--- a/asset_extraction/main.py
+++ b/asset_extraction/main.py
@@ -226,9 +226,15 @@ def execute_script(script_config: dict, asset_file: Path, output_dir: Path):
     )
 
 
-def _refs_from_extractor(extractor_json: Path) -> list[dict]:
+def _refs_from_extractor(
+    extractor_json: Path, asset_access_role: str = "envited-x:isPublic"
+) -> list[dict]:
     """Build input-manifest-style reference dicts from extractor-discovered
-    file references (``scenario:fileReferences``)."""
+    file references (``scenario:fileReferences``).
+
+    Local (relative) paths inherit the access role of the parent asset file.
+    External references (DIDs, URLs) default to ``envited-x:isPublic``.
+    """
     try:
         with extractor_json.open("r", encoding="utf-8") as f:
             data = json.load(f)
@@ -254,12 +260,20 @@ def _refs_from_extractor(extractor_json: Path) -> list[dict]:
         rel_path = entry.get("relativePath", entry.get("path", ""))
         if not rel_path:
             continue
+
+        # Determine access role: local paths inherit from parent asset,
+        # external references (DIDs, URLs) get isPublic.
+        if rel_path.startswith(("did:", "http://", "https://")):
+            role = "envited-x:isPublic"
+        else:
+            role = asset_access_role
+
         suffix = Path(rel_path).suffix.lower()
         refs.append(
             {
                 "@type": "Link",
                 "hasCategory": {"@id": "envited-x:isSimulationData"},
-                "hasAccessRole": {"@id": "envited-x:isPublic"},
+                "hasAccessRole": {"@id": role},
                 "hasFileMetadata": {
                     "@type": "FileMetadata",
                     "filePath": rel_path,
@@ -268,6 +282,34 @@ def _refs_from_extractor(extractor_json: Path) -> list[dict]:
             }
         )
     return refs
+
+
+def _get_asset_access_role(uploaded_file: Path) -> str:
+    """Look up the access role of the simulation-data artifact in the input manifest.
+
+    Returns the full prefixed @id (e.g. 'envited-x:isOwner') or falls back
+    to 'envited-x:isPublic' if not determinable.
+    """
+    fallback = "envited-x:isPublic"
+    try:
+        with uploaded_file.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return fallback
+
+    artifacts = data.get("hasArtifacts", data.get("manifest:hasArtifacts", []))
+    if not isinstance(artifacts, list):
+        artifacts = [artifacts]
+
+    for link in artifacts:
+        cat = link.get("hasCategory", link.get("manifest:hasCategory", {}))
+        cat_id = cat.get("@id", "") if isinstance(cat, dict) else str(cat)
+        if "isSimulationData" in cat_id:
+            role = link.get("hasAccessRole", link.get("manifest:hasAccessRole", {}))
+            role_id = role.get("@id", "") if isinstance(role, dict) else str(role)
+            if role_id:
+                return role_id
+    return fallback
 
 
 def _format_reference(ref: dict) -> dict:
@@ -562,7 +604,8 @@ def main():
     # references).  These are merged with any user-provided references.
     extractor_json = output_sub_dir / "temp" / f"{asset_name}_extractor.json"
     if extractor_json.exists():
-        auto_refs = _refs_from_extractor(extractor_json)
+        asset_role = _get_asset_access_role(uploaded_file)
+        auto_refs = _refs_from_extractor(extractor_json, asset_access_role=asset_role)
         if auto_refs:
             if refs is None:
                 refs = []

--- a/meta_data_extractor/tests/test_xosc_file_references.py
+++ b/meta_data_extractor/tests/test_xosc_file_references.py
@@ -168,6 +168,46 @@ class TestRefsFromExtractor:
         assert refs[1]["hasFileMetadata"]["filePath"] == "models/scene.gltf"
         assert refs[1]["hasFileMetadata"]["mimeType"] == "model/gltf+json"
 
+    def test_local_refs_inherit_access_role(self, tmp_path):
+        from asset_extraction.main import _refs_from_extractor
+
+        extractor_data = {
+            "scenario:fileReferences": [
+                {
+                    "type": "LogicFile",
+                    "path": "map/road.xodr",
+                    "relativePath": "map/road.xodr",
+                },
+            ]
+        }
+        extractor_json = tmp_path / "test_extractor.json"
+        extractor_json.write_text(json.dumps(extractor_data), encoding="utf-8")
+
+        refs = _refs_from_extractor(
+            extractor_json, asset_access_role="envited-x:isOwner"
+        )
+        assert refs[0]["hasAccessRole"]["@id"] == "envited-x:isOwner"
+
+    def test_external_refs_get_public_role(self, tmp_path):
+        from asset_extraction.main import _refs_from_extractor
+
+        extractor_data = {
+            "scenario:fileReferences": [
+                {
+                    "type": "LogicFile",
+                    "path": "did:key:z6Mk.../road.xodr",
+                    "relativePath": "did:key:z6Mk.../road.xodr",
+                },
+            ]
+        }
+        extractor_json = tmp_path / "test_extractor.json"
+        extractor_json.write_text(json.dumps(extractor_data), encoding="utf-8")
+
+        refs = _refs_from_extractor(
+            extractor_json, asset_access_role="envited-x:isOwner"
+        )
+        assert refs[0]["hasAccessRole"]["@id"] == "envited-x:isPublic"
+
     def test_returns_empty_when_no_references(self, tmp_path):
         from asset_extraction.main import _refs_from_extractor
 
@@ -182,3 +222,40 @@ class TestRefsFromExtractor:
 
         refs = _refs_from_extractor(tmp_path / "nonexistent.json")
         assert refs == []
+
+
+class TestGetAssetAccessRole:
+    """Test _get_asset_access_role helper."""
+
+    def test_extracts_owner_role(self, tmp_path):
+        from asset_extraction.main import _get_asset_access_role
+
+        manifest = {
+            "@context": ["https://example.org/"],
+            "hasArtifacts": [
+                {
+                    "@type": "Link",
+                    "hasCategory": {"@id": "envited-x:isSimulationData"},
+                    "hasAccessRole": {"@id": "envited-x:isOwner"},
+                    "hasFileMetadata": {"filePath": "test.xosc"},
+                }
+            ],
+        }
+        f = tmp_path / "input_manifest.json"
+        f.write_text(json.dumps(manifest), encoding="utf-8")
+
+        assert _get_asset_access_role(f) == "envited-x:isOwner"
+
+    def test_fallback_to_public(self, tmp_path):
+        from asset_extraction.main import _get_asset_access_role
+
+        manifest = {"@context": ["https://example.org/"], "hasArtifacts": []}
+        f = tmp_path / "input_manifest.json"
+        f.write_text(json.dumps(manifest), encoding="utf-8")
+
+        assert _get_asset_access_role(f) == "envited-x:isPublic"
+
+    def test_handles_missing_file(self, tmp_path):
+        from asset_extraction.main import _get_asset_access_role
+
+        assert _get_asset_access_role(tmp_path / "nope.json") == "envited-x:isPublic"

--- a/meta_data_extractor/tests/test_xosc_file_references.py
+++ b/meta_data_extractor/tests/test_xosc_file_references.py
@@ -1,0 +1,184 @@
+"""Tests for OpenSCENARIO file-reference extraction."""
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+XOSC_WITH_REFS = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <OpenSCENARIO>
+      <FileHeader revMajor="1" revMinor="3" date="2026-01-01" author="test"
+                  description="test scenario"/>
+      <ParameterDeclarations/>
+      <CatalogLocations>
+        <VehicleCatalog>
+          <Directory path="Catalogs/Vehicles"/>
+        </VehicleCatalog>
+      </CatalogLocations>
+      <RoadNetwork>
+        <LogicFile filepath="map/road.xodr"/>
+        <SceneGraphFile filepath="models/scene.gltf"/>
+      </RoadNetwork>
+      <Entities>
+        <ScenarioObject name="Ego">
+          <Vehicle name="EgoCar" vehicleCategory="car">
+            <BoundingBox><Center x="1.4" y="0.0" z="0.7"/>
+              <Dimensions width="1.8" height="1.4" length="4.5"/>
+            </BoundingBox>
+            <Axles>
+              <FrontAxle maxSteering="0.5" wheelDiameter="0.6"
+                         trackWidth="1.6" positionX="3.1" positionZ="0.3"/>
+              <RearAxle maxSteering="0" wheelDiameter="0.6"
+                        trackWidth="1.6" positionX="0" positionZ="0.3"/>
+            </Axles>
+            <Performance maxSpeed="69.4" maxAcceleration="10" maxDeceleration="10"/>
+          </Vehicle>
+        </ScenarioObject>
+      </Entities>
+      <Storyboard>
+        <Init><Actions/></Init>
+        <StopTrigger/>
+      </Storyboard>
+    </OpenSCENARIO>
+""")
+
+XOSC_NO_REFS = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <OpenSCENARIO>
+      <FileHeader revMajor="1" revMinor="3" date="2026-01-01" author="test"
+                  description="bare scenario"/>
+      <ParameterDeclarations/>
+      <RoadNetwork/>
+      <Entities/>
+      <Storyboard>
+        <Init><Actions/></Init>
+        <StopTrigger/>
+      </Storyboard>
+    </OpenSCENARIO>
+""")
+
+
+@pytest.fixture
+def xosc_with_refs(tmp_path):
+    """Create a minimal XOSC file with LogicFile, SceneGraphFile, and catalog refs."""
+    xosc_file = tmp_path / "test.xosc"
+    xosc_file.write_text(XOSC_WITH_REFS, encoding="utf-8")
+
+    # Create the referenced map so the extractor can resolve it
+    map_dir = tmp_path / "map"
+    map_dir.mkdir()
+    (map_dir / "road.xodr").write_text("<OpenDRIVE/>", encoding="utf-8")
+
+    # Create the scene graph file
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    (model_dir / "scene.gltf").write_text("{}", encoding="utf-8")
+
+    # Create a catalog directory with one file
+    cat_dir = tmp_path / "Catalogs" / "Vehicles"
+    cat_dir.mkdir(parents=True)
+    (cat_dir / "car.xosc").write_text(
+        '<?xml version="1.0"?><OpenSCENARIO><Catalog name="VehicleCatalog"/></OpenSCENARIO>',
+        encoding="utf-8",
+    )
+    return xosc_file
+
+
+@pytest.fixture
+def xosc_no_refs(tmp_path):
+    """Create a bare XOSC file with no file references."""
+    xosc_file = tmp_path / "bare.xosc"
+    xosc_file.write_text(XOSC_NO_REFS, encoding="utf-8")
+    return xosc_file
+
+
+class TestLoadOpenscenarioFileReferences:
+    """Verify file reference extraction from OpenSCENARIO files."""
+
+    def test_logic_file_reference(self, xosc_with_refs):
+        from meta_data_extractor.xosc.extract_osc import load_openscenario_file
+
+        osc = load_openscenario_file(xosc_with_refs)
+        logic_refs = [r for r in osc.file_references if r["type"] == "LogicFile"]
+        assert len(logic_refs) == 1
+        assert logic_refs[0]["path"] == "map/road.xodr"
+        assert "relativePath" in logic_refs[0]
+
+    def test_scene_graph_reference(self, xosc_with_refs):
+        from meta_data_extractor.xosc.extract_osc import load_openscenario_file
+
+        osc = load_openscenario_file(xosc_with_refs)
+        sg_refs = [r for r in osc.file_references if r["type"] == "SceneGraphFile"]
+        assert len(sg_refs) == 1
+        assert sg_refs[0]["path"] == "models/scene.gltf"
+
+    def test_catalog_reference(self, xosc_with_refs):
+        from meta_data_extractor.xosc.extract_osc import load_openscenario_file
+
+        osc = load_openscenario_file(xosc_with_refs)
+        cat_refs = [r for r in osc.file_references if r["type"].startswith("Catalog:")]
+        assert len(cat_refs) >= 1
+        assert any("car.xosc" in r.get("path", "") for r in cat_refs)
+
+    def test_no_refs_when_absent(self, xosc_no_refs):
+        from meta_data_extractor.xosc.extract_osc import load_openscenario_file
+
+        osc = load_openscenario_file(xosc_no_refs)
+        assert osc.file_references == []
+
+    def test_map_location_set(self, xosc_with_refs):
+        from meta_data_extractor.xosc.extract_osc import load_openscenario_file
+
+        osc = load_openscenario_file(xosc_with_refs)
+        assert osc.map_location is not None
+        assert osc.map_location.name == "road.xodr"
+
+
+class TestRefsFromExtractor:
+    """Test _refs_from_extractor helper in asset_extraction."""
+
+    def test_builds_refs_from_file_references(self, tmp_path):
+        from asset_extraction.main import _refs_from_extractor
+
+        extractor_data = {
+            "scenario:fileReferences": [
+                {
+                    "type": "LogicFile",
+                    "path": "map/road.xodr",
+                    "relativePath": "map/road.xodr",
+                },
+                {
+                    "type": "SceneGraphFile",
+                    "path": "models/scene.gltf",
+                    "relativePath": "models/scene.gltf",
+                },
+            ]
+        }
+        extractor_json = tmp_path / "test_extractor.json"
+        extractor_json.write_text(json.dumps(extractor_data), encoding="utf-8")
+
+        refs = _refs_from_extractor(extractor_json)
+        assert len(refs) == 2
+        assert refs[0]["hasCategory"]["@id"] == "envited-x:isSimulationData"
+        assert refs[0]["hasFileMetadata"]["filePath"] == "map/road.xodr"
+        assert refs[0]["hasFileMetadata"]["mimeType"] == "application/xml"
+        assert refs[1]["hasFileMetadata"]["filePath"] == "models/scene.gltf"
+        assert refs[1]["hasFileMetadata"]["mimeType"] == "model/gltf+json"
+
+    def test_returns_empty_when_no_references(self, tmp_path):
+        from asset_extraction.main import _refs_from_extractor
+
+        extractor_json = tmp_path / "empty_extractor.json"
+        extractor_json.write_text("{}", encoding="utf-8")
+
+        refs = _refs_from_extractor(extractor_json)
+        assert refs == []
+
+    def test_returns_empty_on_missing_file(self, tmp_path):
+        from asset_extraction.main import _refs_from_extractor
+
+        refs = _refs_from_extractor(tmp_path / "nonexistent.json")
+        assert refs == []

--- a/meta_data_extractor/tests/test_xosc_file_references.py
+++ b/meta_data_extractor/tests/test_xosc_file_references.py
@@ -188,7 +188,7 @@ class TestRefsFromExtractor:
         )
         assert refs[0]["hasAccessRole"]["@id"] == "envited-x:isOwner"
 
-    def test_external_refs_get_public_role(self, tmp_path):
+    def test_external_refs_get_registered_role(self, tmp_path):
         from asset_extraction.main import _refs_from_extractor
 
         extractor_data = {
@@ -206,7 +206,7 @@ class TestRefsFromExtractor:
         refs = _refs_from_extractor(
             extractor_json, asset_access_role="envited-x:isOwner"
         )
-        assert refs[0]["hasAccessRole"]["@id"] == "envited-x:isPublic"
+        assert refs[0]["hasAccessRole"]["@id"] == "envited-x:isRegistered"
 
     def test_returns_empty_when_no_references(self, tmp_path):
         from asset_extraction.main import _refs_from_extractor

--- a/meta_data_extractor/xosc/extract_osc.py
+++ b/meta_data_extractor/xosc/extract_osc.py
@@ -104,6 +104,8 @@ class OpenSCENARIO:
         self.map_location: Path = None
         self.map_et: ET.Element = None
         self.variables: typing.Dict[str, str] = {}
+        # Collected file references (map, catalogs, scene graph, controllers…)
+        self.file_references: typing.List[typing.Dict[str, str]] = []
 
     def __str__(self) -> str:
         ret = f"OpenSCENARIO: {self.scenario_file}\n\tMap: {self.map_location}\n\tCatalogs:\n"
@@ -358,6 +360,19 @@ def get_osc_value(el: ET.Element, key: str, osc: OpenSCENARIO) -> str:
     return value
 
 
+def _add_file_reference(
+    osc: OpenSCENARIO, ref_type: str, filepath: str, resolved: Path | None = None
+):
+    """Register a discovered file reference on the OpenSCENARIO object."""
+    entry: typing.Dict[str, str] = {"type": ref_type, "path": filepath}
+    if resolved is not None:
+        try:
+            entry["relativePath"] = str(resolved.relative_to(osc.scenario_file.parent))
+        except ValueError:
+            entry["relativePath"] = str(resolved)
+    osc.file_references.append(entry)
+
+
 def load_openscenario_file(osc_path: Path) -> OpenSCENARIO:
     osc = OpenSCENARIO()
     osc.scenario_file = osc_path.resolve()
@@ -366,31 +381,60 @@ def load_openscenario_file(osc_path: Path) -> OpenSCENARIO:
     osc.scenario_et = sc
     extract_variables(osc, sc)
 
+    # --- LogicFile (HD-map reference) ---
     logic_file = sc.find(".//LogicFile")
-    filepath = get_osc_value(logic_file, "filepath", osc)
-    osc.map_location = (osc_path.parent / filepath).resolve()
+    if logic_file is not None and "filepath" in logic_file.attrib:
+        filepath = get_osc_value(logic_file, "filepath", osc)
+        osc.map_location = (osc_path.parent / filepath).resolve()
 
-    logger.debug(f"Loading map {osc.map_location}")
-    if not osc.map_location.exists():
-        # try local
-        osc.map_location = (osc_path.parent / Path(filepath).name).resolve()
+        logger.debug(f"Loading map {osc.map_location}")
         if not osc.map_location.exists():
-            logger.warning(
-                f"Referenced map not found locally: {osc.map_location} "
-                f"— treating as external asset reference"
-            )
-            osc.map_location = None
+            # try local
+            osc.map_location = (osc_path.parent / Path(filepath).name).resolve()
+            if not osc.map_location.exists():
+                logger.warning(
+                    f"Referenced map not found locally: {osc.map_location} "
+                    f"— treating as external asset reference"
+                )
+                _add_file_reference(osc, "LogicFile", filepath)
+                osc.map_location = None
+            else:
+                _add_file_reference(osc, "LogicFile", filepath, osc.map_location)
+        else:
+            _add_file_reference(osc, "LogicFile", filepath, osc.map_location)
 
-    if ".//CatalogLocations" in sc:
-        for catalog in sc.find(".//CatalogLocations"):
-            if (
-                "path" not in catalog.find(".//Directory").attrib
-                or catalog.find(".//Directory").attrib["path"] == ""
-            ):
+    # --- SceneGraphFile (3-D environment model reference) ---
+    scene_graph = sc.find(".//SceneGraphFile")
+    if scene_graph is not None and "filepath" in scene_graph.attrib:
+        sg_path = get_osc_value(scene_graph, "filepath", osc)
+        resolved = (osc_path.parent / sg_path).resolve()
+        _add_file_reference(
+            osc, "SceneGraphFile", sg_path, resolved if resolved.exists() else None
+        )
+
+    # --- TrafficSignalController (informational, not a file reference) ---
+    # Controllers are defined inline in the XOSC or in the LogicFile (XODR).
+    # We record their names so downstream can list them as dependencies.
+    for tsc in sc.findall(".//TrafficSignalController"):
+        ref_el = tsc.find("Phase/TrafficSignalState")
+        if ref_el is not None:
+            entry: typing.Dict[str, str] = {
+                "type": "TrafficSignalController",
+                "name": tsc.attrib.get("name", ""),
+            }
+            osc.file_references.append(entry)
+
+    # --- CatalogLocations ---
+    catalog_locations_el = sc.find(".//CatalogLocations")
+    if catalog_locations_el is not None:
+        for catalog in catalog_locations_el:
+            dir_el = catalog.find("Directory")
+            if dir_el is None:
                 continue
-            location = (
-                osc_path.parent / catalog.find(".//Directory").attrib["path"]
-            ).resolve()
+            cat_path = dir_el.attrib.get("path", "")
+            if not cat_path:
+                continue
+            location = (osc_path.parent / cat_path).resolve()
             osc.catalogs[catalog.tag] = []
             osc.catalog_locations[catalog.tag] = []
             if location.is_dir():
@@ -399,9 +443,14 @@ def load_openscenario_file(osc_path: Path) -> OpenSCENARIO:
                         logger.debug(f"Loading catalog {file}")
                         osc.catalogs[catalog.tag].append(ET.parse(file).getroot())
                         osc.catalog_locations[catalog.tag].append(file)
+                        _add_file_reference(
+                            osc, f"Catalog:{catalog.tag}", str(file.name), file
+                        )
             elif location.is_file():
                 logger.debug(f"Loading catalog {location}")
                 osc.catalogs[catalog.tag].append(ET.parse(location).getroot())
+                osc.catalog_locations[catalog.tag].append(location)
+                _add_file_reference(osc, f"Catalog:{catalog.tag}", cat_path, location)
     return osc
 
 
@@ -1785,6 +1834,12 @@ def get_meta_data(
     )  # TODO currently empty
     # TODO DataSource with sourceType, sourceDescription
     set_manifest_data(meta_data_dict, osc)
+
+    # File references discovered in the OpenSCENARIO XML (map, catalogs,
+    # scene graph, controllers).  Downstream pipeline stages can use these
+    # to auto-populate manifest:hasReferencedArtifacts.
+    if osc.file_references:
+        meta_data_dict["scenario:fileReferences"] = osc.file_references
 
     return meta_data_dict
 


### PR DESCRIPTION
## Problem

OpenSCENARIO (`.xosc`) files reference external resources — HD-maps (`LogicFile`), 3-D environment models (`SceneGraphFile`), catalog directories, and traffic signal controllers — but the pipeline did not surface these in the output manifest. Users had to manually declare all referenced artifacts in the input manifest under `hasReferencedArtifacts`.

Additionally, the extractor crashed when a `LogicFile` element was missing or had no `filepath` attribute, and CatalogLocations detection used an unreliable string-in-element check instead of proper XPath.

Closes #8

## Solution

### Extractor (`meta_data_extractor/xosc/extract_osc.py`)

- Add `file_references` list to `OpenSCENARIO` class to collect all discovered references
- Extract **LogicFile** (HD-map), **SceneGraphFile** (3-D model), **CatalogLocations** (catalog files), and **TrafficSignalController** references
- Fix CatalogLocations detection: replace `"path" not in catalog.find(...)` with proper `find("Directory")` + attribute check
- Guard against missing `LogicFile` element (previously crashed with `AttributeError`)
- Output discovered references as `scenario:fileReferences` in the extractor JSON

### Pipeline (`asset_extraction/main.py`)

- Add `_refs_from_extractor()` helper that reads `scenario:fileReferences` from extractor JSON and builds manifest-compatible `Link` entries
- **Access role inheritance**: local/relative paths inherit the access role of the parent asset (looked up from the input manifest via `_get_asset_access_role()`); external references (DIDs, URLs) default to `envited-x:isRegistered` (requires dataspace membership)
- Auto-populate `hasReferencedArtifacts` from discovered references, merged with any user-provided references
- MIME type mapping for common simulation formats (`.xodr`, `.gltf`, `.glb`, `.fbx`, `.obj`)
- Fix: guard against `None` return from `load_referenced_artifacts()` before calling `.extend()`

## Access Role Logic

| Reference type | Example | Access role |
|---|---|---|
| Local/relative path | `map/road.xodr` | Inherited from parent asset (e.g. `isOwner`) |
| DID reference | `did:key:z6Mk.../road.xodr` | `isRegistered` |
| URL reference | `https://example.com/map.xodr` | `isRegistered` |

## Testing

13 tests covering:
- LogicFile reference extraction (resolved path)
- SceneGraphFile reference extraction
- Catalog file reference extraction
- Bare XOSC with no references produces empty list
- Map location set correctly when file exists
- `_refs_from_extractor()`: builds refs with correct MIME types
- `_refs_from_extractor()`: local refs inherit access role from parent
- `_refs_from_extractor()`: external (DID) refs get `isRegistered`
- `_refs_from_extractor()`: empty JSON → empty list
- `_refs_from_extractor()`: missing file → empty list
- `_get_asset_access_role()`: extracts owner role from manifest
- `_get_asset_access_role()`: falls back to public when no artifacts
- `_get_asset_access_role()`: handles missing file gracefully

All 434 existing tests continue to pass.

## Example

Given an input manifest where the scenario is `isOwner`:
```json
"hasArtifacts": [{
  "hasCategory": {"@id": "envited-x:isSimulationData"},
  "hasAccessRole": {"@id": "envited-x:isOwner"},
  "hasFileMetadata": {"filePath": "scenario.xosc"}
}]
```

And the XOSC references:
```xml
<RoadNetwork>
  <LogicFile filepath="map/road.xodr"/>
  <SceneGraphFile filepath="models/scene.gltf"/>
</RoadNetwork>
```

The pipeline injects into `manifest.json` with the inherited role:
```json
"manifest:hasReferencedArtifacts": [
  {
    "@type": "manifest:Link",
    "hasAccessRole": {"@type": "manifest:AccessRole", "@id": "envited-x:isOwner"},
    "hasCategory": {"@type": "manifest:Category", "@id": "envited-x:isSimulationData"},
    "manifest:hasFileMetadata": {
      "@type": "manifest:FileMetadata",
      "filePath": "map/road.xodr",
      "mimeType": "application/xml"
    }
  }
]
```
