### PR TITLE
feat: integrate wizard CLI with sd-creation-wizard-api backend

### DIFF
--- a/wizard_caller/api_client.py
+++ b/wizard_caller/api_client.py
@@ -1,0 +1,81 @@
+"""HTTP client for the SD Creation Wizard API.
+
+Delegates SHACL parsing and JSON-LD pre-filling to the sd-creation-wizard-api
+service (Spring Boot) which correctly handles conditional SHACL constructs
+(sh:or, sh:and, sh:xone) that the local rdflib-based parser cannot resolve.
+
+The API is expected to run at ``WIZARD_API_URL`` (default
+``http://localhost:8080``) — start it via::
+
+    docker compose -f docker-compose.wizard.yml up -d sd-creation-wizard-api
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_URL = "http://localhost:8080"
+_TIMEOUT = 60  # seconds
+
+
+class WizardAPIError(Exception):
+    """Raised when the Wizard API returns a non-success response."""
+
+
+def convert_and_prefill(
+    api_url: str,
+    shacl_path: Path,
+    jsonld_path: Path,
+    timeout: int = _TIMEOUT,
+) -> dict:
+    """Send SHACL + JSON-LD to the API and return the combined result.
+
+    Calls ``POST /convertAndPrefillFile`` with multipart form data.
+
+    Returns:
+        A dict with keys ``shaclModel`` (the converted shape schema
+        including ``sh:or`` branches) and ``matchedSubjects`` (a flat
+        map of property-URI → current-value extracted from the JSON-LD).
+
+    Raises:
+        WizardAPIError: on HTTP 4xx / 5xx or connection failure.
+    """
+    url = f"{api_url.rstrip('/')}/convertAndPrefillFile"
+
+    try:
+        with open(shacl_path, "rb") as shacl_f, open(jsonld_path, "rb") as json_f:
+            files = {
+                "file": (shacl_path.name, shacl_f, "text/turtle"),
+                "jsonFile": (jsonld_path.name, json_f, "application/json"),
+            }
+            resp = requests.post(url, files=files, timeout=timeout)
+    except requests.ConnectionError as exc:
+        raise WizardAPIError(
+            f"Cannot connect to Wizard API at {api_url}. "
+            f"Start it with: docker compose -f docker-compose.wizard.yml up -d sd-creation-wizard-api"
+        ) from exc
+    except requests.Timeout as exc:
+        raise WizardAPIError(f"Wizard API request timed out after {timeout}s") from exc
+    except OSError as exc:
+        raise WizardAPIError(f"Cannot read input file: {exc}") from exc
+
+    if resp.status_code != 200:
+        raise WizardAPIError(
+            f"Wizard API returned HTTP {resp.status_code}: {resp.text[:500]}"
+        )
+
+    return resp.json()
+
+
+def is_api_available(api_url: str) -> bool:
+    """Check whether the Wizard API is reachable."""
+    try:
+        resp = requests.get(f"{api_url.rstrip('/')}/getAvailableShapes", timeout=5)
+        return resp.status_code == 200
+    except (requests.ConnectionError, requests.Timeout):
+        return False

--- a/wizard_caller/main.py
+++ b/wizard_caller/main.py
@@ -3,15 +3,22 @@
 When enabled, parses SHACL shape constraints and interactively prompts
 the user to fill in missing JSON-LD metadata fields.  When disabled,
 simply copies the input JSON-LD to the output path unchanged.
+
+Supports two backends (selected via ``-api-url``):
+
+* **local** (default) — parse SHACL with rdflib (basic constraints)
+* **api**   — delegate to the sd-creation-wizard-api for full SHACL
+  support including ``sh:or``, ``sh:and``, ``sh:xone``
 """
 
 import argparse
 import logging
+import os
 import shutil
 import sys
 from pathlib import Path
 
-from wizard_caller.shacl_wizard import run_wizard
+from wizard_caller.shacl_wizard import run_wizard, run_wizard_api
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +36,15 @@ def main():
         help="'true' to run interactive wizard, 'false' to copy unchanged",
     )
     parser.add_argument("-out", required=True, help="Output JSON-LD file path")
+    parser.add_argument(
+        "-api-url",
+        default=None,
+        help=(
+            "URL of the sd-creation-wizard-api (e.g. http://localhost:8080). "
+            "Falls back to env var WIZARD_API_URL. "
+            "If set, uses the API backend for full SHACL support (sh:or, etc.)"
+        ),
+    )
     args = parser.parse_args()
 
     jsonld_path = Path(args.filename)
@@ -44,6 +60,24 @@ def main():
         shutil.copy2(jsonld_path, output_path)
         logger.info("Wizard disabled — copied %s → %s", jsonld_path, output_path)
         return
+
+    api_url = args.api_url or os.environ.get("WIZARD_API_URL")
+
+    if api_url:
+        from wizard_caller.api_client import WizardAPIError, is_api_available
+
+        if is_api_available(api_url):
+            logger.info("Using Wizard API at %s", api_url)
+            try:
+                run_wizard_api(jsonld_path, shacl_path, output_path, api_url)
+                return
+            except WizardAPIError as exc:
+                logger.warning("API call failed: %s — falling back to local mode", exc)
+        else:
+            logger.warning(
+                "Wizard API at %s is not reachable — falling back to local mode",
+                api_url,
+            )
 
     run_wizard(jsonld_path, shacl_path, output_path)
 

--- a/wizard_caller/shacl_wizard.py
+++ b/wizard_caller/shacl_wizard.py
@@ -3,6 +3,12 @@
 Parses a combined SHACL Turtle file to discover required and optional
 properties, compares against an existing JSON-LD instance, and prompts
 the user to fill in any missing values interactively.
+
+Supports two backends:
+
+* **local** — parse SHACL with rdflib (basic constraints only)
+* **api**   — delegate to the sd-creation-wizard-api which handles
+  conditional SHACL constructs (``sh:or``, ``sh:and``, ``sh:xone``)
 """
 
 from __future__ import annotations
@@ -282,7 +288,7 @@ def _compact(uri: str, prefix_map: dict) -> str:
 
 
 def run_wizard(jsonld_path: Path, shacl_path: Path, output_path: Path) -> bool:
-    """Run the interactive CLI wizard.
+    """Run the interactive CLI wizard using local SHACL parsing.
 
     Returns True if the JSON-LD was modified.
     """
@@ -300,7 +306,7 @@ def run_wizard(jsonld_path: Path, shacl_path: Path, output_path: Path) -> bool:
                         prefix_map[k] = v
 
     print(f"\n{'=' * 60}")
-    print("  SD Creation Wizard  (CLI)")
+    print("  SD Creation Wizard  (CLI — local mode)")
     print(f"{'=' * 60}")
     print(f"  JSON-LD : {jsonld_path.name}")
     print(f"  SHACL   : {shacl_path.name}")
@@ -308,6 +314,232 @@ def run_wizard(jsonld_path: Path, shacl_path: Path, output_path: Path) -> bool:
     print(f"  \033[91m*\033[0m = required field")
 
     modified = enrich(data, by_target, by_shape, prefix_map)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+    if modified:
+        print(f"\n\033[92m[OK]\033[0m Enhanced JSON-LD written to {output_path}")
+    else:
+        print(f"\n[OK] No changes — JSON-LD copied to {output_path}")
+
+    return modified
+
+
+# ── API-backed enrichment ───────────────────────────────────────────
+
+
+def _prompt_api_property(
+    constraint: dict, current: str | None = None
+) -> str | tuple[str, str] | None:
+    """Prompt the user for a single property based on API shape constraints.
+
+    Returns:
+        A string value for simple properties, a ``(prop_key, value)`` tuple
+        when an ``sh:or`` branch carries its own path, or *current* unchanged.
+    """
+    required = (constraint.get("minCount") or 0) >= 1
+    tag = "\033[91m*\033[0m" if required else " "
+    name = constraint.get("name", constraint.get("path", {}).get("value", "?"))
+
+    desc_map = constraint.get("description") or {}
+    desc = desc_map.get("en", "")
+
+    print(f"\n  {tag} {name}", end="")
+    if desc:
+        print(f"  —  {desc}", end="")
+    print()
+
+    if current is not None:
+        print(f"    Current: \033[92m{current}\033[0m")
+
+    # sh:or — let user pick which branch
+    or_options = constraint.get("or")
+    if or_options and isinstance(or_options, list):
+        print("    This property allows alternative types:")
+        for i, opt in enumerate(or_options, 1):
+            opt_path = opt.get("path", {})
+            opt_name = opt.get("name") or (
+                f"{opt_path.get('prefix', '')}:{opt_path.get('value', '')}"
+                if opt_path.get("value")
+                else f"Option {i}"
+            )
+            print(f"    {i}) {opt_name}")
+        raw = input(f"    Select [1–{len(or_options)}] (Enter to skip): ").strip()
+        if not raw:
+            return current
+        if raw.isdigit() and 1 <= int(raw) <= len(or_options):
+            selected = or_options[int(raw) - 1]
+            result = _prompt_api_property(selected, current)
+            # If the selected branch has its own path, return (key, value)
+            # so the caller knows which JSON-LD key to use.
+            branch_path = selected.get("path") or {}
+            if branch_path.get("value"):
+                branch_key = (
+                    f"{branch_path['prefix']}:{branch_path['value']}"
+                    if branch_path.get("prefix")
+                    else branch_path["value"]
+                )
+                val = result[1] if isinstance(result, tuple) else result
+                return (branch_key, val)
+            return result
+        print("    Invalid selection — keeping current value.")
+        return current
+
+    # sh:in — enumeration
+    in_options = constraint.get("in") or []
+    if in_options:
+        for i, opt in enumerate(in_options, 1):
+            val = opt.get("value", str(opt)) if isinstance(opt, dict) else str(opt)
+            marker = " \033[92m←\033[0m" if val == current else ""
+            print(f"    {i}) {val}{marker}")
+        raw = input(f"    Select [1–{len(in_options)}]: ").strip()
+        if not raw:
+            return current
+        if raw.isdigit() and 1 <= int(raw) <= len(in_options):
+            opt = in_options[int(raw) - 1]
+            return opt.get("value", str(opt)) if isinstance(opt, dict) else str(opt)
+        print("    Invalid selection — keeping current value.")
+        return current
+
+    # Typed input
+    dt = constraint.get("datatype") or {}
+    type_label = dt.get("value", "text") if isinstance(dt, dict) else "text"
+    hint = " (Enter to keep)" if current is not None else ""
+    raw = input(f"    [{type_label}]{hint}: ").strip()
+
+    if not raw:
+        return current
+    return raw
+
+
+def _enrich_from_api(
+    json_data: dict,
+    shapes: list[dict],
+    matched: dict[str, str],
+    prefix_list: list[dict],
+) -> bool:
+    """Walk the API shape model and prompt for missing/empty values.
+
+    Returns True if json_data was modified.
+    """
+    modified = False
+
+    for shape in shapes:
+        shape_name = shape.get("schema", "")
+        constraints = shape.get("constraints") or []
+        if not constraints:
+            continue
+
+        print(f"\n{'─' * 56}")
+        print(f"  {shape_name}")
+        print(f"{'─' * 56}")
+
+        for constraint in constraints:
+            # sh:or at the constraint level (no path on wrapper itself)
+            # — the branches carry their own paths.
+            or_options = constraint.get("or")
+            if (
+                or_options
+                and isinstance(or_options, list)
+                and not constraint.get("path")
+            ):
+                new_val = _prompt_api_property(constraint, None)
+                if isinstance(new_val, tuple):
+                    branch_key, branch_val = new_val
+                    if branch_val is not None:
+                        json_data[branch_key] = branch_val
+                        modified = True
+                continue
+
+            path_info = constraint.get("path") or {}
+            prefix = path_info.get("prefix", "")
+            value = path_info.get("value", "")
+            if not value:
+                continue
+
+            # Build the full property key used in the JSON-LD
+            prop_key = f"{prefix}:{value}" if prefix else value
+
+            # Children → nested shape (recurse when data available)
+            children_ref = constraint.get("children")
+            if children_ref:
+                # Find the nested shape
+                nested = next(
+                    (s for s in shapes if s.get("schema") == children_ref), None
+                )
+                if nested and isinstance(json_data.get(prop_key), dict):
+                    sub = _enrich_from_api(
+                        json_data[prop_key], [nested], matched, prefix_list
+                    )
+                    modified = modified or sub
+                continue
+
+            # Leaf property — check matched value and prompt
+            # Build possible URI keys for the matched map
+            ns_url = ""
+            for p in prefix_list:
+                if p.get("alias") == prefix:
+                    ns_url = p.get("url", "")
+                    break
+            full_uri = f"{ns_url}{value}" if ns_url else prop_key
+
+            current = matched.get(full_uri) or json_data.get(prop_key)
+            if isinstance(current, dict):
+                current = current.get("@value", current.get("value"))
+
+            new_val = _prompt_api_property(constraint, current)
+
+            # _prompt_api_property may return (key, value) for sh:or branches
+            if isinstance(new_val, tuple):
+                branch_key, branch_val = new_val
+                if branch_val is not None and branch_val != current:
+                    json_data[branch_key] = branch_val
+                    modified = True
+            elif new_val is not None and new_val != current:
+                json_data[prop_key] = new_val
+                modified = True
+
+    return modified
+
+
+def run_wizard_api(
+    jsonld_path: Path,
+    shacl_path: Path,
+    output_path: Path,
+    api_url: str,
+) -> bool:
+    """Run the wizard using the sd-creation-wizard-api backend.
+
+    The API resolves conditional SHACL constructs (sh:or, sh:and, etc.)
+    that the local parser cannot handle.
+
+    Returns True if the JSON-LD was modified.
+    """
+    from wizard_caller.api_client import convert_and_prefill
+
+    result = convert_and_prefill(api_url, shacl_path, jsonld_path)
+
+    shacl_model = result.get("shaclModel", {})
+    matched = result.get("matchedSubjects", {})
+    shapes = shacl_model.get("shapes", [])
+    prefix_list = shacl_model.get("prefixList", [])
+
+    with open(jsonld_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    print(f"\n{'=' * 60}")
+    print("  SD Creation Wizard  (CLI — API mode)")
+    print(f"{'=' * 60}")
+    print(f"  JSON-LD  : {jsonld_path.name}")
+    print(f"  SHACL    : {shacl_path.name}")
+    print(f"  API      : {api_url}")
+    print(f"  Shapes   : {len(shapes)} resolved")
+    print(f"  Prefilled: {len(matched)} value(s)")
+    print(f"  \033[91m*\033[0m = required field")
+
+    modified = _enrich_from_api(data, shapes, matched, prefix_list)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:

--- a/wizard_caller/tests/test_wizard_api.py
+++ b/wizard_caller/tests/test_wizard_api.py
@@ -1,0 +1,298 @@
+"""Tests for the wizard API client and API-backed enrichment."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wizard_caller.api_client import (
+    WizardAPIError,
+    convert_and_prefill,
+    is_api_available,
+)
+
+
+# ── API client tests ─────────────────────────────────────────────────
+
+
+class TestIsApiAvailable:
+    @patch("wizard_caller.api_client.requests.get")
+    def test_returns_true_when_reachable(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200)
+        assert is_api_available("http://localhost:8080") is True
+
+    @patch("wizard_caller.api_client.requests.get")
+    def test_returns_false_on_connection_error(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.ConnectionError("refused")
+        assert is_api_available("http://localhost:8080") is False
+
+    @patch("wizard_caller.api_client.requests.get")
+    def test_returns_false_on_timeout(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.Timeout("timed out")
+        assert is_api_available("http://localhost:8080") is False
+
+
+class TestConvertAndPrefill:
+    @patch("wizard_caller.api_client.requests.post")
+    def test_success(self, mock_post, tmp_path):
+        expected = {
+            "shaclModel": {"prefixList": [], "shapes": []},
+            "matchedSubjects": {"http://example.com/prop": "value"},
+        }
+        mock_post.return_value = MagicMock(status_code=200, json=lambda: expected)
+
+        shacl = tmp_path / "test.ttl"
+        shacl.write_text("# empty", encoding="utf-8")
+        jsonld = tmp_path / "test.json"
+        jsonld.write_text("{}", encoding="utf-8")
+
+        result = convert_and_prefill("http://localhost:8080", shacl, jsonld)
+        assert result == expected
+
+    @patch("wizard_caller.api_client.requests.post")
+    def test_raises_on_http_error(self, mock_post, tmp_path):
+        mock_post.return_value = MagicMock(status_code=400, text="Bad Input")
+
+        shacl = tmp_path / "test.ttl"
+        shacl.write_text("# empty", encoding="utf-8")
+        jsonld = tmp_path / "test.json"
+        jsonld.write_text("{}", encoding="utf-8")
+
+        with pytest.raises(WizardAPIError, match="HTTP 400"):
+            convert_and_prefill("http://localhost:8080", shacl, jsonld)
+
+    @patch("wizard_caller.api_client.requests.post")
+    def test_raises_on_connection_error(self, mock_post, tmp_path):
+        import requests
+
+        mock_post.side_effect = requests.ConnectionError("refused")
+
+        shacl = tmp_path / "test.ttl"
+        shacl.write_text("# empty", encoding="utf-8")
+        jsonld = tmp_path / "test.json"
+        jsonld.write_text("{}", encoding="utf-8")
+
+        with pytest.raises(WizardAPIError, match="Cannot connect"):
+            convert_and_prefill("http://localhost:8080", shacl, jsonld)
+
+
+# ── API-backed enrichment tests ──────────────────────────────────────
+
+
+class TestEnrichFromApi:
+    def test_no_change_when_shapes_empty(self):
+        from wizard_caller.shacl_wizard import _enrich_from_api
+
+        data = {"@type": "test:Thing"}
+        modified = _enrich_from_api(data, [], {}, [])
+        assert modified is False
+
+    @patch("builtins.input", return_value="new value")
+    def test_modifies_data_with_user_input(self, mock_input):
+        from wizard_caller.shacl_wizard import _enrich_from_api
+
+        data = {"@type": "test:Thing"}
+        shapes = [
+            {
+                "schema": "ThingShape",
+                "constraints": [
+                    {
+                        "path": {"prefix": "test", "value": "name"},
+                        "name": "Name",
+                        "description": {"en": "The name"},
+                        "minCount": 1,
+                        "datatype": {"value": "String"},
+                        "in": [],
+                        "or": None,
+                        "children": None,
+                    }
+                ],
+            }
+        ]
+        prefix_list = [{"alias": "test", "url": "http://example.com/test/"}]
+
+        modified = _enrich_from_api(data, shapes, {}, prefix_list)
+        assert modified is True
+        assert data["test:name"] == "new value"
+
+    @patch("builtins.input", return_value="")
+    def test_keeps_matched_value_on_empty_input(self, mock_input):
+        from wizard_caller.shacl_wizard import _enrich_from_api
+
+        data = {"@type": "test:Thing", "test:name": "existing"}
+        shapes = [
+            {
+                "schema": "ThingShape",
+                "constraints": [
+                    {
+                        "path": {"prefix": "test", "value": "name"},
+                        "name": "Name",
+                        "description": {},
+                        "minCount": 0,
+                        "datatype": {"value": "String"},
+                        "in": [],
+                        "or": None,
+                        "children": None,
+                    }
+                ],
+            }
+        ]
+        prefix_list = [{"alias": "test", "url": "http://example.com/test/"}]
+        matched = {"http://example.com/test/name": "existing"}
+
+        modified = _enrich_from_api(data, shapes, matched, prefix_list)
+        assert modified is False
+        assert data["test:name"] == "existing"
+
+    @patch("builtins.input", side_effect=["1", "Alice"])
+    def test_shor_at_constraint_level_without_path(self, mock_input):
+        """sh:or wrapper has no path — branches carry their own paths."""
+        from wizard_caller.shacl_wizard import _enrich_from_api
+
+        data = {"@type": "test:Thing"}
+        shapes = [
+            {
+                "schema": "ThingShape",
+                "constraints": [
+                    {
+                        "name": "Name (choose one)",
+                        "description": {},
+                        "or": [
+                            {
+                                "path": {"prefix": "test", "value": "firstName"},
+                                "name": "First Name",
+                                "minCount": 1,
+                                "datatype": {"value": "String"},
+                            },
+                            {
+                                "path": {"prefix": "test", "value": "givenName"},
+                                "name": "Given Name",
+                                "minCount": 1,
+                                "datatype": {"value": "String"},
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+
+        modified = _enrich_from_api(data, shapes, {}, [])
+        assert modified is True
+        # User selected branch 1 (firstName) and entered "Alice"
+        assert data["test:firstName"] == "Alice"
+        assert "test:givenName" not in data
+
+    @patch("builtins.input", side_effect=[""])
+    def test_shor_at_constraint_level_skip(self, mock_input):
+        """User presses Enter to skip an sh:or choice — no modification."""
+        from wizard_caller.shacl_wizard import _enrich_from_api
+
+        data = {"@type": "test:Thing"}
+        shapes = [
+            {
+                "schema": "ThingShape",
+                "constraints": [
+                    {
+                        "name": "Name (choose one)",
+                        "or": [
+                            {
+                                "path": {"prefix": "test", "value": "firstName"},
+                                "name": "First Name",
+                                "datatype": {"value": "String"},
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+
+        modified = _enrich_from_api(data, shapes, {}, [])
+        assert modified is False
+
+    @patch("builtins.input", side_effect=["1", "Bob"])
+    def test_shor_on_property_with_path(self, mock_input):
+        """sh:or on a constraint that ALSO has its own path — branch key wins."""
+        from wizard_caller.shacl_wizard import _enrich_from_api
+
+        data = {"@type": "test:Thing"}
+        shapes = [
+            {
+                "schema": "ThingShape",
+                "constraints": [
+                    {
+                        "path": {"prefix": "test", "value": "identifier"},
+                        "name": "Identifier",
+                        "description": {},
+                        "or": [
+                            {
+                                "path": {"prefix": "test", "value": "codeEPSG"},
+                                "name": "EPSG code",
+                                "minCount": 1,
+                                "datatype": {"value": "integer"},
+                            },
+                            {
+                                "path": {
+                                    "prefix": "test",
+                                    "value": "coordinateSystemName",
+                                },
+                                "name": "Coordinate system name",
+                                "minCount": 1,
+                                "datatype": {"value": "String"},
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+
+        modified = _enrich_from_api(data, shapes, {}, [])
+        assert modified is True
+        # Branch key "test:codeEPSG" is used, not the wrapper key "test:identifier"
+        assert data["test:codeEPSG"] == "Bob"
+
+
+# ── main.py fallback logic ───────────────────────────────────────────
+
+
+class TestMainFallback:
+    """Verify that main() falls back to local mode when API is unavailable."""
+
+    @patch("wizard_caller.shacl_wizard.run_wizard")
+    @patch("wizard_caller.api_client.is_api_available", return_value=False)
+    def test_falls_back_to_local_when_api_unreachable(
+        self, mock_available, mock_run_wizard, tmp_path
+    ):
+        from wizard_caller.main import main
+
+        jsonld = tmp_path / "test.json"
+        jsonld.write_text('{"@type": "test:Thing"}', encoding="utf-8")
+        shacl = tmp_path / "test.ttl"
+        shacl.write_text("# empty", encoding="utf-8")
+        out = tmp_path / "out.json"
+
+        with patch(
+            "sys.argv",
+            [
+                "wizard_caller",
+                str(jsonld),
+                "-shacl",
+                str(shacl),
+                "-enable",
+                "true",
+                "-out",
+                str(out),
+                "-api-url",
+                "http://localhost:8080",
+            ],
+        ):
+            main()
+
+        mock_available.assert_called_once()
+        mock_run_wizard.assert_called_once()


### PR DESCRIPTION
Closes #14 - See commit message for full details.

**Problem:** CLI wizard cannot handle conditional SHACL (sh:or, sh:and, sh:xone) because it parses shapes locally with rdflib.

**Solution:** Delegate SHACL resolution to the sd-creation-wizard-api (Spring Boot) which already handles these correctly.

**Changes:**
- New api_client.py: HTTP client for the wizard API (convert, prefill, health check)
- shacl_wizard.py: Add run_wizard_api() with API-backed enrichment supporting sh:or branches
- main.py: Add -api-url flag + WIZARD_API_URL env var, auto-detect API with graceful fallback to local mode
- 11 new tests covering API client, enrichment, and fallback logic

**Usage:**
Start the API: docker compose -f docker-compose.wizard.yml up -d sd-creation-wizard-api
Run with API: python -m wizard_caller.main file.json -shacl shapes.ttl -enable true -out out.json -api-url http://localhost:8080