### PR TITLE
fix: handle internal QC checker errors as warnings instead of crashing pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,7 @@ qc = [
     # Switch back to @v1.0.0 (or newer) once the PR is merged.
     "asam-qc-opendrive@git+https://github.com/jdsika/qc-opendrive@fix-contact-point-missing-road-link",
     "asam-qc-openscenarioxml@git+https://github.com/asam-ev/qc-openscenarioxml@v1.0.0",
-    # Pinned to fix branch pending upstream PR openMSL/sl-5-9-openmsl-qc-opendrive#1.
-    # Switch back to @main once the PR is merged.
-    "openmsl-qc-opendrive@git+https://github.com/openMSL/sl-5-9-openmsl-qc-opendrive@fix/object-outline-height-keyerror",
+    "openmsl-qc-opendrive@git+https://github.com/openMSL/sl-5-9-openmsl-qc-opendrive@main",
 ]
 qc-deps = [
     "pyclothoids",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ qc = [
     # Switch back to @v1.0.0 (or newer) once the PR is merged.
     "asam-qc-opendrive@git+https://github.com/jdsika/qc-opendrive@fix-contact-point-missing-road-link",
     "asam-qc-openscenarioxml@git+https://github.com/asam-ev/qc-openscenarioxml@v1.0.0",
-    "openmsl-qc-opendrive@git+https://github.com/openMSL/sl-5-9-openmsl-qc-opendrive@main",
+    # Pinned to fix branch pending upstream PR openMSL/sl-5-9-openmsl-qc-opendrive#1.
+    # Switch back to @main once the PR is merged.
+    "openmsl-qc-opendrive@git+https://github.com/openMSL/sl-5-9-openmsl-qc-opendrive@fix/object-outline-height-keyerror",
 ]
 qc-deps = [
     "pyclothoids",

--- a/qualitychecker_caller/main.py
+++ b/qualitychecker_caller/main.py
@@ -168,10 +168,18 @@ def get_checker_bundle_summary(result_file: Path) -> str | None:
     return bundle.get("summary", "").strip() if bundle is not None else None
 
 
-def fail_on_internal_checker_errors(
+def warn_on_internal_checker_errors(
     app_name: str, result_file: Path, text_report: Path | None = None
 ) -> None:
-    """Stop the pipeline when the QC tool completed with internal checker errors."""
+    """Log a warning when the QC tool completed with internal checker errors.
+
+    Internal checker errors indicate bugs in individual checker code (e.g. an
+    upstream checker crashing on valid input) — not problems with the asset
+    being checked.  The XQAR report and text report are still generated, so
+    the pipeline can continue and users can review what went wrong.
+
+    See https://github.com/openMSL/sl-5-8-asset-tools/issues/19.
+    """
 
     errors = get_internal_checker_errors(result_file)
     if not errors:
@@ -182,8 +190,11 @@ def fail_on_internal_checker_errors(
         details += f"; ... ({len(errors)} total)"
 
     report_hint = f" See {text_report} for details." if text_report else ""
-    raise SystemExit(
-        f"{app_name} reported internal checker errors: {details}{report_hint}"
+    logger.warning(
+        "%s reported internal checker errors: %s%s",
+        app_name,
+        details,
+        report_hint,
     )
 
 
@@ -248,7 +259,7 @@ def main():
         text_report_path = Path(f"{output_file.with_suffix('')}_QCReport.txt")
         _generate_text_report(output_file, text_report_path)
 
-        fail_on_internal_checker_errors(app_name, output_file, text_report_path)
+        warn_on_internal_checker_errors(app_name, output_file, text_report_path)
         summary = get_checker_bundle_summary(output_file)
         if summary:
             logger.info("%s: %s", app_name, summary)

--- a/utils/pipeline_reporting.py
+++ b/utils/pipeline_reporting.py
@@ -322,13 +322,39 @@ def _summarize_quality_checker(cmd: list[str], project_root: Path) -> StageSumma
             details=[f"Expected result: {_display_path(result_file, project_root)}"],
         )
 
-    tree = ET.parse(result_file)
+    try:
+        tree = ET.parse(result_file)
+    except ET.ParseError:
+        return StageSummary(
+            status="warn",
+            message="quality checks completed with malformed XQAR",
+            details=[f"Expected result: {_display_path(result_file, project_root)}"],
+        )
     bundle = tree.find(".//CheckerBundle")
     summary = bundle.get("summary", "").strip() if bundle is not None else ""
     compact = _compact_bundle_summary(summary)
 
     detail_path = str(result_file.with_suffix("")) + "_QCReport.txt"
     details = [f"Report: {_display_path(detail_path, project_root)}"]
+
+    # Detect internal checker errors (e.g. upstream checker bugs) and surface
+    # them as warnings so the pipeline continues but the user is informed.
+    # See https://github.com/openMSL/sl-5-8-asset-tools/issues/19.
+    error_checkers = [
+        c.get("checkerId", "unknown")
+        for c in tree.findall(".//Checker[@status='error']")
+    ]
+    if error_checkers:
+        details.append(
+            f"Internal errors in: {', '.join(error_checkers[:3])}"
+            + (f" (+{len(error_checkers) - 3} more)" if len(error_checkers) > 3 else "")
+        )
+        return StageSummary(
+            status="warn",
+            message=compact or "quality checks completed",
+            details=details,
+        )
+
     return StageSummary(message=compact or "quality checks completed", details=details)
 
 


### PR DESCRIPTION
## Summary

Fixes #19 — Pipeline crashes when processing OpenDRIVE files containing polygonal objects defined via `<outline>` elements.

## Root Cause

The upstream checker `check_openmsl_xodr_road_object_size` in [sl-5-9-openmsl-qc-opendrive](https://github.com/openMSL/sl-5-9-openmsl-qc-opendrive) uses unsafe direct dict access (`object.attrib["height"]`) instead of `.get("height")`. For polygonal objects, `height`/`width`/`length` attributes are not present on the `<object>` element — their geometry is defined via `<outline>`/`<cornerLocal>` children. This is fully valid per the ASAM OpenDRIVE standard.

The ASAM QC framework catches the resulting `KeyError` and records it as an internal checker error (`StatusType.ERROR`) in the XQAR report. Previously, `fail_on_internal_checker_errors()` in `qualitychecker_caller/main.py` would detect this and raise `SystemExit`, killing the entire pipeline.

## Changes

### `qualitychecker_caller/main.py`
- Renamed `fail_on_internal_checker_errors` → `warn_on_internal_checker_errors`
- Instead of `raise SystemExit(...)`, now logs `logger.warning(...)`
- The XQAR report and text report are still generated and available for user review
- The pipeline continues to produce the `asset.zip` archive

### `utils/pipeline_reporting.py`
- Extended `_summarize_quality_checker` to detect `Checker[@status='error']` in the XQAR and return `StageSummary(status="warn")` instead of `"ok"`
- This surfaces internal checker errors as **stage warnings** in the pipeline output so users are clearly informed which checkers had problems
- Added `try/except ET.ParseError` guard for additional resilience against malformed XQAR files

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| QC checker with internal error | Pipeline crashes with `SystemExit` | Pipeline continues, stage shows ⚠️ WARN |
| QC checker succeeds normally | Pipeline continues, stage shows ✅ OK | No change |
| Malformed XQAR file | Pipeline crashes with XML parse error | Stage shows ⚠️ WARN with diagnostic message |

## Trade-offs

Internal checker errors (bugs in upstream checker code) are distinct from quality issues found in the asset data. Making them non-fatal is the right default because:
1. The QC reports (XQAR + text) are still generated and contain full details
2. A bug in one checker should not prevent the rest of the pipeline from producing results
3. The warnings are clearly visible in the pipeline output and log

The upstream bug in `road_object_size.py` should still be fixed in `sl-5-9-openmsl-qc-opendrive` — this PR makes the pipeline resilient to such issues.