### PR TITLE
fix: migrate gx:name/gx:description to schema:name/schema:description

### DIFF
--- a/jsonLD_creator/main.py
+++ b/jsonLD_creator/main.py
@@ -490,7 +490,7 @@ def score_shape_match(shape_properties: list, data_dict: dict) -> int:
         path = get_value("path", prop)
         if path:
             ns, ln = get_namespace_name_from_url(path)
-            # Create the key as it appears in the source JSON (e.g., "gx:name")
+            # Create the key as it appears in the source JSON (e.g., "schema:name")
             prop_key = create_namespace_name(ns, ln)
             if prop_key in data_keys:
                 score += 1

--- a/meta_data_extractor/xodr/extract_odr.py
+++ b/meta_data_extractor/xodr/extract_odr.py
@@ -201,8 +201,8 @@ def extract_meta_data(file: Path) -> Tuple[bool, dict]:
 
     # Resource description
     resource_desc: dict = {}
-    resource_desc["gx:name"] = file.stem
-    resource_desc["gx:description"] = "road network"
+    resource_desc["schema:name"] = file.stem
+    resource_desc["schema:description"] = "road network"
     enrich_resource_description(resource_desc, file)
     meta_data_dict["hdmap:hasResourceDescription"] = resource_desc
 

--- a/meta_data_extractor/xosc/extract_osc.py
+++ b/meta_data_extractor/xosc/extract_osc.py
@@ -166,12 +166,12 @@ def extract_meta_data(file: Path) -> Tuple[bool, dict]:
 
     # Resource description
     resource_desc: dict = {}
-    resource_desc["gx:name"] = file.stem
+    resource_desc["schema:name"] = file.stem
     description = extracted.pop("scenario:description", None)
     if description:
-        resource_desc["gx:description"] = description
+        resource_desc["schema:description"] = description
     else:
-        resource_desc["gx:description"] = "OpenSCENARIO file"
+        resource_desc["schema:description"] = "OpenSCENARIO file"
     enrich_resource_description(resource_desc, file)
     meta_data_dict["scenario:hasResourceDescription"] = resource_desc
 

--- a/structure_creator/main.py
+++ b/structure_creator/main.py
@@ -381,16 +381,18 @@ def get_name_description_from_domainMetadata(filename, type):
     with open(filename, "r", encoding="utf-8") as file:
         data = json.load(file)
 
-    name = safe_get(data, [f"{type}:hasResourceDescription", "gx:name"])
+    name = safe_get(data, [f"{type}:hasResourceDescription", "schema:name"])
     if not name:
         logger.error(
-            f"name : {type}:hasResourceDescription -> gx:name not exists in {filename}"
+            f"name : {type}:hasResourceDescription -> schema:name not exists in {filename}"
         )
 
-    description = safe_get(data, [f"{type}:hasResourceDescription", "gx:description"])
+    description = safe_get(
+        data, [f"{type}:hasResourceDescription", "schema:description"]
+    )
     if not description:
         logger.error(
-            f"description: {type}:hasResourceDescription -> gx:description not exists in {filename}"
+            f"description: {type}:hasResourceDescription -> schema:description not exists in {filename}"
         )
 
     return name, description


### PR DESCRIPTION
## Problem

The `Testfall_Carlo-BMW` example (and any OpenSCENARIO/OpenDRIVE pipeline run) crashes at SHACL validation (stage 6) with:

> *Each ResourceDescription must have a textual description of the entity.*

## Root Cause

The SHACL ontology (`gx.shacl.ttl`) updated `VirtualResourceShape` to use `schema:name` and `schema:description` instead of the old `gx:name` / `gx:description` properties. The metadata extractors and structure_creator still emitted the old keys, causing `jsonLD_creator` to silently drop them (no SHACL property match).

## Changes

| File | Change |
|------|--------|
| `meta_data_extractor/xodr/extract_odr.py` | `gx:name` → `schema:name`, `gx:description` → `schema:description` |
| `meta_data_extractor/xosc/extract_osc.py` | Same |
| `structure_creator/main.py` | Updated key lookups to read the new property names |
| `jsonLD_creator/main.py` | Comment fix only |

## Verification

- ✅ OpenDRIVE example pipeline passes all 14 stages
- ✅ Testfall_Carlo-BMW now passes the previously-failing SHACL validation (stage 6)
  - Note: a separate pre-existing `entityTypes` validation issue remains (unrelated)