### PR TITLE
fix: round speed limits and mark non-georeferenced GeoJSON

### DIFF
--- a/meta_data_extractor/xodr/extract_odr.py
+++ b/meta_data_extractor/xodr/extract_odr.py
@@ -252,7 +252,7 @@ def extract_meta_data(file: Path) -> Tuple[bool, dict]:
     if "hdmap:speedLimit" in extracted:
         speed_str = extracted.pop("hdmap:speedLimit")
         if isinstance(speed_str, str) and speed_str:
-            speeds = sorted(float(s) for s in speed_str.split(", ") if s)
+            speeds = sorted(round(float(s), 2) for s in speed_str.split(", ") if s)
             quantity_dict["hdmap:speedLimit"] = {
                 "hdmap:min": speeds[0] if speeds else 0.0,
                 "hdmap:max": speeds[-1] if speeds else 50.0,

--- a/xodr_routing_creator/main.py
+++ b/xodr_routing_creator/main.py
@@ -57,7 +57,9 @@ def create_kml(elements: list, output_file: Path, isPolygon: bool):
 
 
 # create and write data as GeoJson elements
-def create_geojson(elements: list, output_file: Path, isPolygon: bool):
+def create_geojson(
+    elements: list, output_file: Path, isPolygon: bool, is_georeferenced: bool = True
+):
     features = []
     for element in elements:
         if isPolygon:
@@ -81,6 +83,11 @@ def create_geojson(elements: list, output_file: Path, isPolygon: bool):
         features.append(feature)
 
     geojson = {"type": "FeatureCollection", "features": features}
+    if not is_georeferenced:
+        geojson["properties"] = {
+            "crs": "local",
+            "note": "Coordinates are in local meters (no georeference)",
+        }
 
     # write GeoJSON
     write_json(output_file, geojson, indentValue=2)
@@ -134,7 +141,13 @@ def main():
         # Reproject the coordinates
         transformed_lines = reproject(lines, offset, transformer_proj_to_wgs84)
     else:
+        logger.warning(
+            "No georeference/projection found in OpenDRIVE file. "
+            "GeoJSON output will use local coordinates (not WGS84)."
+        )
         transformed_lines = reproject(lines, offset, None)
+
+    is_georeferenced = projection is not None
 
     # crate and write bounding box
     output_file_box = Path(args.box) if args.box else None
@@ -152,13 +165,13 @@ def main():
         boxes.append(coordinates)
         box_extension = output_file_box.suffix.lower()
         if box_extension == ".geojson":
-            create_geojson(boxes, output_file_box, True)
+            create_geojson(boxes, output_file_box, True, is_georeferenced)
         else:
             create_kml(boxes, output_file_box, True)
 
     # write line data
     if extension == ".geojson":
-        create_geojson(transformed_lines, output_file, False)
+        create_geojson(transformed_lines, output_file, False, is_georeferenced)
     else:
         create_kml(transformed_lines, output_file, False)
 


### PR DESCRIPTION
## Summary

Addresses items 2 and 3 from #26.

### Changes

1. **Speed limit precision** — rounds to 2 decimal places (33.333... → 33.33 m/s)
2. **Non-georeferenced GeoJSON** — adds `crs: "local"` property + warning log when OpenDRIVE has no projection string

### Not included

- **Testfall_Carlo-BMW** manifest fix — example data is gitignored, must be fixed at source

Refs #26