### PR TITLE
feat(wizard): add .env-based port configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# SD Creation Wizard configuration
+WIZARD_API_PORT=3007
+WIZARD_FRONTEND_PORT=5174

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/*.egg-info
 **/.vscode
 .venv/
+.env
 shacls/
 qc_config.xml
 examples/assets/
@@ -10,3 +11,4 @@ examples/**/*.zip
 examples/*/
 !examples/OpenDRIVE/
 !examples/OpenSCENARIO/
+.playground/

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ OMB  := submodules/ontology-management-base
 WIZARD_DIR := submodules/sd-creation-wizard
 GIT  ?= git
 
+# Load .env for wizard ports
+-include .env
+WIZARD_API_PORT      ?= 3007
+WIZARD_FRONTEND_PORT ?= 5174
+
 # OS detection for cross-platform support (Windows vs Unix)
 ifeq ($(OS),Windows_NT)
     SHELL            := sh
@@ -326,7 +331,8 @@ else
 	@if kill -0 $$(cat /tmp/sd-wizard-api.pid) 2>/dev/null; then \
 		echo ""; \
 		echo "[OK] Wizard API is running:"; \
-		echo "  API: http://localhost:3007"; \
+		echo "  API:      http://localhost:$(WIZARD_API_PORT)"; \
+		echo "  Frontend: http://localhost:$(WIZARD_FRONTEND_PORT)"; \
 		echo ""; \
 		echo "  Stop with:  make wizard stop"; \
 	else \

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Run `make help` for the full list of available commands.
 Two ready-to-run examples are included under `examples/`:
 
 ```bash
-make generate opendrive      # OpenDRIVE example  → examples/OpenDRIVE/output/ + examples/OpenDRIVE/<CID>.zip
-make generate openscenario   # OpenSCENARIO example → examples/OpenSCENARIO/output/ + examples/OpenSCENARIO/<CID>.zip
+make generate opendrive      # OpenDRIVE example  → examples/assets/
+make generate openscenario   # OpenSCENARIO example → examples/assets/
 ```
 
 ### Selective Module Execution
@@ -151,7 +151,7 @@ python -m asset_extraction.main -config configs -list-modules
 make generate INPUT_DIR=path/to/input
 ```
 
-`OUTPUT_DIR` defaults to a sibling `output/` directory (e.g. `path/to/output`).
+`OUTPUT_DIR` defaults to `examples/assets/`.
 Override explicitly if needed:
 
 ```bash
@@ -160,10 +160,10 @@ make generate INPUT_DIR=path/to/input OUTPUT_DIR=/tmp/my-output
 
 The `INPUT_DIR` must contain an `input_manifest.json`. This is the mode used by downstream asset repositories (e.g. `hd-map-asset-example`) to delegate pipeline execution.
 
-Each example follows the `input/` → `output/` convention:
+Each input example follows this convention:
 
-- `examples/<name>/input/` — input manifest, simulation data, media, docs, LICENSE
-- `examples/<name>/output/` — pipeline-generated EVES-003 asset (gitignored)
+- `examples/<source>/<name>/<type>/` — input manifest, simulation data, media, docs, LICENSE
+- `examples/assets/` — pipeline-generated EVES-003 assets (gitignored)
 
 By default the pipeline uses concise, stage-oriented logging. To inspect raw
 child command lines and full stdout/stderr, set `SL58_LOG_MODE=debug` before
@@ -238,7 +238,7 @@ the pipeline continues.
 The simplest way to use the wizard — just add `WIZARD=true`:
 
 ```bash
-WIZARD=true make generate INPUT_DIR=examples/IKA/SCEN-95B774BAC0A9/hdmap/input
+WIZARD=true make generate INPUT_DIR=examples/ika/SCEN-95B774BAC0A9/hdmap
 ```
 
 This runs the full pipeline and at the wizard step:
@@ -272,7 +272,14 @@ python -m wizard_caller.main metadata/hdmap.json -shacl temp/hdmap.ttl -enable t
 | Service  | URL                    | Purpose |
 |----------|------------------------|---------|
 | API      | <http://localhost:3007> | SHACL parsing, session management |
-| Frontend | <http://localhost:4200> | Angular wizard UI |
+| Frontend | <http://localhost:5174> | React wizard UI |
+
+Ports are configurable via `.env` (see `.env.example`):
+
+```env
+WIZARD_API_PORT=3007
+WIZARD_FRONTEND_PORT=5174
+```
 
 ## Notes
 

--- a/wizard_caller/README.md
+++ b/wizard_caller/README.md
@@ -33,8 +33,10 @@ python -m wizard_caller.main <jsonld_file> -shacl <combined_shacl.ttl> -enable <
 | Variable | Effect |
 |----------|--------|
 | `WIZARD_ENABLED=true` | Activates wizard even when config says `-enable false` |
-| `WIZARD_API_URL` | Override API URL (default: `http://localhost:3007`) |
-| `WIZARD_FRONTEND_URL` | Override frontend URL (default: `http://localhost:5173`) |
+| `WIZARD_API_PORT` | API port (default: `3007`, loaded from `.env`) |
+| `WIZARD_FRONTEND_PORT` | Frontend port (default: `5174`, loaded from `.env`) |
+| `WIZARD_API_URL` | Override full API URL (default: `http://localhost:$WIZARD_API_PORT`) |
+| `WIZARD_FRONTEND_URL` | Override full frontend URL (default: `http://localhost:$WIZARD_FRONTEND_PORT`) |
 
 ## Arguments
 

--- a/wizard_caller/api_client.py
+++ b/wizard_caller/api_client.py
@@ -10,9 +10,12 @@ The API is expected to run at ``WIZARD_API_URL`` (default
 
     cd submodules/sd-creation-wizard && pnpm dev:api
 
-The React frontend runs at ``http://localhost:5173`` via::
+The React frontend runs at ``http://localhost:5174`` via::
 
     cd submodules/sd-creation-wizard && pnpm dev:wizard
+
+Ports are configurable via ``.env`` file or environment variables
+(``WIZARD_API_PORT``, ``WIZARD_FRONTEND_PORT``).
 """
 
 from __future__ import annotations
@@ -30,8 +33,28 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_API_URL = "http://localhost:3007"
-DEFAULT_FRONTEND_URL = "http://localhost:5173"
+
+def _load_dotenv() -> None:
+    """Load .env file from project root if it exists."""
+    env_file = Path(__file__).resolve().parent.parent / ".env"
+    if not env_file.exists():
+        return
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+            os.environ.setdefault(key.strip(), value.strip())
+
+
+_load_dotenv()
+
+_API_PORT = os.environ.get("WIZARD_API_PORT", "3007")
+_FRONTEND_PORT = os.environ.get("WIZARD_FRONTEND_PORT", "5174")
+
+DEFAULT_API_URL = f"http://localhost:{_API_PORT}"
+DEFAULT_FRONTEND_URL = f"http://localhost:{_FRONTEND_PORT}"
 _TIMEOUT = 60  # seconds
 _POLL_INTERVAL = 2  # seconds
 _BROWSER_WAIT_TIMEOUT = 600  # 10 minutes max for user interaction
@@ -273,7 +296,7 @@ def _start_frontend(wizard_dir: Path) -> bool:
     pnpm = shutil.which("pnpm") or "pnpm"
 
     proc = subprocess.Popen(
-        [pnpm, "vite", "--port", "5173"],
+        [pnpm, "vite", "--port", _FRONTEND_PORT],
         cwd=str(wizard_app_dir),
         stdin=subprocess.DEVNULL,
         stdout=open("/tmp/sd-wizard-frontend.log", "w"),  # noqa: SIM115


### PR DESCRIPTION
## Summary

Adds `.env`-based configuration for the SD Creation Wizard ports, replacing hardcoded values and avoiding port conflicts (5173 is commonly used by other dev tools).

## Changes

- **`.env.example`** (new): Reference config with `WIZARD_API_PORT=3007` and `WIZARD_FRONTEND_PORT=5174`
- **`.gitignore`**: Excludes `.env` (user-local) and `.playground/` (test output)
- **`Makefile`**: Loads `.env` via `-include`, exposes port variables with `?=` (env/CLI always wins)
- **`wizard_caller/api_client.py`**: Added `_load_dotenv()` — reads `.env` from project root without external dependencies (no python-dotenv needed)
- **`README.md`**: Updated wizard section with new ports and `.env` reference
- **`wizard_caller/README.md`**: Updated environment variable table

## Configuration Precedence

```
CLI/env override > .env file > code defaults
```

## Testing

- `make check` passes (lint + compile + readme)
- `WIZARD=true make generate INPUT_DIR=... OUTPUT_DIR=.playground` correctly starts wizard on port 3007/5174
- Non-wizard pipeline unaffected (full 14-stage run completes successfully)

## Port Rationale

- **API 3007**: Avoids common dev ports (3000-3005)
- **Frontend 5174**: Avoids 5173 conflict with vitepress/other Vite projects