### PR TITLE
feat(llm-enricher): add rule-based metadata enrichment module

### DIFF
--- a/configs/config_llm_enricher.json
+++ b/configs/config_llm_enricher.json
@@ -1,0 +1,18 @@
+{
+    "name": "llm_enricher",
+    "environment type": "python",
+    "data folder": "metadata",
+    "params": {
+        "call": "llm_enricher.main",
+        "input": {
+            "enrich": "{path}"
+        },
+        "output": {
+            "--output-path": "{path}/{sub_path}/{asset_type}.json"
+        },
+        "additional": {
+            "--asset-type": "{asset_type}",
+            "--source-dir": "{asset_path}"
+        }
+    }
+}

--- a/configs/process.json
+++ b/configs/process.json
@@ -54,6 +54,14 @@
 			"filename": "config_wizard_caller.json"
 		},
 		{
+			"enable": false,
+			"filename": "config_llm_enricher.json",
+			"extensions": [
+				"xodr",
+				"xosc"
+			]
+		},
+		{
 			"enable": true,
 			"filename": "config_jsonLD_validator_omb.json"
 		},

--- a/llm_enricher/__init__.py
+++ b/llm_enricher/__init__.py
@@ -1,0 +1,8 @@
+"""LLM-based metadata enrichment for simulation assets.
+
+Analyzes source asset files (.xodr, .xosc) and existing metadata to fill
+empty fields using LLM reasoning. Uses SHACL vocabulary to constrain
+outputs to valid values (inspired by ontology-based-nl-search patterns).
+
+Can run as a standalone evaluation tool or as an optional pipeline step.
+"""

--- a/llm_enricher/__main__.py
+++ b/llm_enricher/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/llm_enricher/analyzer.py
+++ b/llm_enricher/analyzer.py
@@ -1,0 +1,196 @@
+"""Asset file analyzer — extracts signals from source files for LLM context.
+
+Parses .xodr (OpenDRIVE) and .xosc (OpenSCENARIO) files to extract
+structured signals that help the LLM fill missing metadata fields.
+"""
+
+import logging
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_asset(asset_path: Path) -> dict[str, Any]:
+    """Analyze an asset file and extract metadata signals."""
+    suffix = asset_path.suffix.lower()
+    if suffix == ".xodr":
+        return _analyze_xodr(asset_path)
+    elif suffix == ".xosc":
+        return _analyze_xosc(asset_path)
+    else:
+        logger.warning("Unsupported file type: %s", suffix)
+        return {}
+
+
+def _analyze_xodr(path: Path) -> dict[str, Any]:
+    """Extract metadata signals from an OpenDRIVE file."""
+    tree = ET.parse(str(path))
+    root = tree.getroot()
+    signals: dict[str, Any] = {"file_type": "OpenDRIVE", "file_name": path.stem}
+
+    header = root.find("header")
+    if header is not None:
+        signals["header"] = {
+            k: header.get(k, "") for k in ["name", "revMajor", "revMinor", "date"]
+        }
+        geo = header.find("geoReference")
+        if geo is not None and geo.text:
+            signals["geo_reference"] = geo.text.strip()
+
+    roads = root.findall("road")
+    signals["road_count"] = len(roads)
+
+    road_types = set()
+    lane_types = set()
+    traffic_rules = set()
+    has_signals = False
+    has_objects = False
+
+    for road in roads:
+        rule = road.get("rule", "")
+        if rule:
+            traffic_rules.add(rule)
+
+        for rtype in road.findall("type"):
+            t = rtype.get("type", "")
+            if t:
+                road_types.add(t)
+
+        for lane in road.findall(".//lane"):
+            lt = lane.get("type", "")
+            if lt:
+                lane_types.add(lt)
+
+        if road.findall(".//signal"):
+            has_signals = True
+        if road.findall(".//object"):
+            has_objects = True
+
+    signals["road_types"] = sorted(road_types)
+    signals["lane_types"] = sorted(lane_types)
+    signals["traffic_rules"] = sorted(traffic_rules)
+    signals["has_signals"] = has_signals
+    signals["has_objects"] = has_objects
+
+    # Traffic direction inference
+    if traffic_rules:
+        if "RHT" in traffic_rules:
+            signals["inferred_traffic_direction"] = "right-hand"
+        elif "LHT" in traffic_rules:
+            signals["inferred_traffic_direction"] = "left-hand"
+
+    junctions = root.findall("junction")
+    signals["junction_count"] = len(junctions)
+
+    return signals
+
+
+def _analyze_xosc(path: Path) -> dict[str, Any]:
+    """Extract metadata signals from an OpenSCENARIO file."""
+    tree = ET.parse(str(path))
+    root = tree.getroot()
+    signals: dict[str, Any] = {"file_type": "OpenSCENARIO", "file_name": path.stem}
+
+    header = root.find("FileHeader")
+    if header is not None:
+        signals["header"] = {
+            k: header.get(k, "")
+            for k in ["description", "author", "revMajor", "revMinor", "date"]
+        }
+
+    entities = root.findall(".//ScenarioObject") + root.findall(".//EntitySelection")
+    signals["entity_count"] = len(entities)
+
+    entity_types = set()
+    for entity in root.findall(".//ScenarioObject"):
+        for vehicle in entity.findall(".//Vehicle"):
+            vtype = vehicle.get("vehicleCategory", vehicle.get("name", ""))
+            if vtype:
+                entity_types.add(vtype.lower())
+        for pedestrian in entity.findall(".//Pedestrian"):
+            entity_types.add("pedestrian")
+        for misc in entity.findall(".//MiscObject"):
+            entity_types.add("obstacle")
+
+    signals["entity_types"] = sorted(entity_types)
+
+    # Action analysis for scenario category inference
+    action_types = set()
+    for elem in root.iter():
+        tag = elem.tag
+        if tag.endswith("Action") and tag != "Action":
+            action_types.add(tag)
+
+    signals["action_types"] = sorted(action_types)
+
+    # Maneuver names for category clues
+    maneuver_names = []
+    for m in root.findall(".//Maneuver"):
+        name = m.get("name", "")
+        if name:
+            maneuver_names.append(name)
+    signals["maneuver_names"] = maneuver_names
+
+    # Weather
+    weather = root.find(".//Weather")
+    if weather is not None:
+        signals["has_weather"] = True
+        cloud = weather.get("fractionalCloudCover", "")
+        if cloud:
+            signals["cloud_cover"] = cloud
+
+        fog = weather.find("Fog")
+        if fog is not None:
+            vis = fog.get("visualRange", "")
+            signals["fog_visual_range"] = vis
+
+        precip = weather.find("Precipitation")
+        if precip is not None:
+            ptype = precip.get("precipitationType", "")
+            intensity = precip.get("intensity", "0")
+            signals["precipitation"] = {"type": ptype, "intensity": intensity}
+
+        sun = weather.find("Sun")
+        if sun is not None:
+            signals["sun"] = {
+                k: sun.get(k, "") for k in ["azimuth", "elevation", "illuminance"]
+            }
+
+    # Time of day
+    tod = root.find(".//TimeOfDay")
+    if tod is not None:
+        signals["time_of_day"] = tod.get("dateTime", "")
+
+    # Positions for geo inference
+    world_positions = []
+    for wp in root.findall(".//WorldPosition"):
+        x, y = wp.get("x", ""), wp.get("y", "")
+        if x and y:
+            world_positions.append({"x": float(x), "y": float(y)})
+    if world_positions:
+        signals["world_positions_sample"] = world_positions[:5]
+
+    # Parameter declarations
+    params = []
+    for p in root.findall(".//ParameterDeclaration"):
+        params.append({"name": p.get("name", ""), "value": p.get("value", "")})
+    if params:
+        signals["parameters"] = params[:10]
+
+    # Controllers
+    controllers = []
+    for c in root.findall(".//Controller"):
+        controllers.append(c.get("name", ""))
+    if controllers:
+        signals["controllers"] = controllers
+
+    # Custom commands
+    custom_cmds = []
+    for cc in root.findall(".//CustomCommandAction"):
+        custom_cmds.append(cc.get("type", ""))
+    if custom_cmds:
+        signals["custom_commands"] = custom_cmds
+
+    return signals

--- a/llm_enricher/enricher.py
+++ b/llm_enricher/enricher.py
@@ -1,0 +1,438 @@
+"""Rule-based metadata enrichment from asset analysis signals.
+
+This module fills metadata fields deterministically from file content
+without needing an LLM. Fields that can be directly extracted or
+trivially inferred go through rules; the remaining gaps are marked
+for optional LLM enrichment.
+"""
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Mapping from maneuver/action keywords to scenario categories
+CATEGORY_KEYWORDS: dict[str, list[str]] = {
+    "cut-in": ["cutin", "cut_in", "cut-in", "cutout", "cut_out", "cut-out"],
+    "emergency-braking": ["emergency", "braking", "deceleration", "aeb"],
+    "following": ["following", "follow"],
+    "free-driving": ["free_driving", "free-driving", "freedriving"],
+    "intersection-crossing": ["intersection", "crossing", "junction"],
+    "lane-change": ["lane_change", "lanechange", "lane-change"],
+    "merging": ["merging", "merge"],
+    "overtaking": ["overtaking", "overtake", "passing"],
+    "parking": ["parking", "park"],
+    "pedestrian-crossing": ["pedestrian_crossing", "pedestrian-crossing", "crosswalk"],
+    "turning": ["turn", "left_turn", "right_turn"],
+}
+
+WEATHER_MAP: dict[str, str] = {
+    "zeroOktas": "clear",
+    "oneOktas": "clear",
+    "twoOktas": "clear",
+    "threeOktas": "clear",
+    "fourOktas": "clear",
+    "fiveOktas": "clear",
+    "sixOktas": "clear",
+    "sevenOktas": "clear",
+    "eightOktas": "clear",
+    "nineOktas": "clear",
+}
+
+
+def enrich_scenario(
+    signals: dict[str, Any],
+    existing: dict[str, Any],
+    vocabulary: dict[str, Any],
+) -> dict[str, Any]:
+    """Fill missing scenario metadata fields from analysis signals.
+
+    Returns a dict of {field_name: enriched_value} for fields that
+    could be determined. Values are None for fields that couldn't.
+    """
+    enriched: dict[str, Any] = {}
+    confidence: dict[str, str] = {}
+
+    # scenarioCategory
+    category = _infer_scenario_category(signals)
+    if category:
+        enriched["scenarioCategory"] = category
+        confidence["scenarioCategory"] = "high"
+
+    # sourceType
+    source_type = _infer_source_type(signals)
+    if source_type:
+        enriched["sourceType"] = source_type
+        confidence["sourceType"] = "medium"
+
+    # sourceDescription
+    source_desc = _infer_source_description(signals)
+    if source_desc:
+        enriched["sourceDescription"] = source_desc
+        confidence["sourceDescription"] = "medium"
+
+    # aim
+    aim = _infer_aim(signals)
+    if aim:
+        enriched["aim"] = aim
+        confidence["aim"] = "medium"
+
+    # country
+    country = _infer_country(signals)
+    if country:
+        enriched["country"] = country
+        confidence["country"] = "medium"
+
+    # movementDescription
+    movement = _infer_movement_description(signals)
+    if movement:
+        enriched["movementDescription"] = movement
+        confidence["movementDescription"] = "medium"
+
+    # criticalityFactors
+    criticality = _infer_criticality_factors(signals, vocabulary)
+    if criticality:
+        enriched["criticalityFactors"] = criticality
+        confidence["criticalityFactors"] = "medium"
+
+    # weatherSummary (if not already filled)
+    if "weatherSummary" not in existing:
+        weather = _infer_weather(signals)
+        if weather:
+            enriched["weatherSummary"] = weather
+            confidence["weatherSummary"] = "high"
+
+    # controllers
+    if signals.get("controllers"):
+        enriched["controllers"] = ", ".join(signals["controllers"])
+        confidence["controllers"] = "high"
+
+    # customCommands
+    if signals.get("custom_commands"):
+        enriched["customCommands"] = ", ".join(signals["custom_commands"])
+        confidence["customCommands"] = "high"
+
+    # permanentTrafficObjects / temporaryTrafficObjects
+    misc_count = len(
+        [e for e in signals.get("entity_types", []) if e in ("obstacle", "miscobject")]
+    )
+    enriched["permanentTrafficObjects"] = misc_count
+    confidence["permanentTrafficObjects"] = "medium"
+    enriched["temporaryTrafficObjects"] = 0
+    confidence["temporaryTrafficObjects"] = "low"
+
+    # Validate enum values against SHACL vocabulary
+    _validate_enums(enriched, confidence, vocabulary)
+
+    return {"fields": enriched, "confidence": confidence}
+
+
+def enrich_hdmap(
+    signals: dict[str, Any],
+    existing: dict[str, Any],
+    vocabulary: dict[str, Any],
+) -> dict[str, Any]:
+    """Fill missing hdmap metadata fields from analysis signals."""
+    enriched: dict[str, Any] = {}
+    confidence: dict[str, str] = {}
+
+    # trafficDirection
+    td = signals.get("inferred_traffic_direction")
+    if td:
+        enriched["trafficDirection"] = td
+        confidence["trafficDirection"] = "high"
+
+    # levelOfDetail
+    lod = _infer_level_of_detail(signals)
+    if lod:
+        enriched["levelOfDetail"] = lod
+        confidence["levelOfDetail"] = "medium"
+
+    # usedDataSources
+    source = _infer_hdmap_source(signals)
+    if source:
+        enriched["usedDataSources"] = source
+        confidence["usedDataSources"] = "medium"
+
+    # sourceDescription
+    desc = _infer_hdmap_source_description(signals)
+    if desc:
+        enriched["sourceDescription"] = desc
+        confidence["sourceDescription"] = "low"
+
+    # Validate enum values against SHACL vocabulary
+    _validate_enums(enriched, confidence, vocabulary)
+
+    return {"fields": enriched, "confidence": confidence}
+
+
+def _validate_enums(
+    enriched: dict[str, Any],
+    confidence: dict[str, str],
+    vocabulary: dict[str, Any],
+) -> None:
+    """Remove enriched values that violate SHACL sh:in constraints."""
+    enums = vocabulary.get("enums", {})
+    for field_name in list(enriched):
+        if field_name not in enums:
+            continue
+        valid_values = set(enums[field_name].get("values", []))
+        value = enriched[field_name]
+        if isinstance(value, list):
+            filtered = [v for v in value if v in valid_values]
+            if filtered:
+                enriched[field_name] = filtered
+            else:
+                del enriched[field_name]
+                confidence.pop(field_name, None)
+        elif value not in valid_values:
+            del enriched[field_name]
+            confidence.pop(field_name, None)
+
+
+def _infer_scenario_category(signals: dict[str, Any]) -> str | None:
+    """Infer scenario category from file name, maneuvers, and actions."""
+    search_text = " ".join(
+        [
+            signals.get("file_name", ""),
+            " ".join(signals.get("maneuver_names", [])),
+            signals.get("header", {}).get("description", ""),
+        ]
+    ).lower()
+
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        if any(kw in search_text for kw in keywords):
+            return category
+
+    # Action-based inference
+    actions = set(a.lower() for a in signals.get("action_types", []))
+    if "lanechangeaction" in actions:
+        return "lane-change"
+    if "followtrajectoryaction" in actions:
+        return "following"
+
+    return None
+
+
+def _infer_source_type(signals: dict[str, Any]) -> str | None:
+    """Infer data source type from author and file metadata."""
+    author = signals.get("header", {}).get("author", "").lower()
+    desc = signals.get("header", {}).get("description", "").lower()
+    fname = signals.get("file_name", "").lower()
+
+    if "vufo" in fname or "verkehrsunfall" in author:
+        return "Accident Database"
+    if "wmg" in author or "verification and validation" in author:
+        return "Analytical Hazard Based Approach"
+    if "scenariotoolkit" in author or "auto-generated" in desc:
+        return "Synthetic Generation"
+    if any(kw in author for kw in ["safetypool", "safety pool", "safety-pool"]):
+        return "Accident Database"
+    if "manual" in desc:
+        return "Manual Authoring"
+
+    # UUID-style names often indicate Safety Pool (accident database)
+    if re.match(r"^[0-9a-fA-F]{8}-", fname):
+        return "Accident Database"
+
+    return None
+
+
+def _infer_source_description(signals: dict[str, Any]) -> str | None:
+    """Build a source description from available signals."""
+    author = signals.get("header", {}).get("author", "")
+    desc = signals.get("header", {}).get("description", "")
+
+    parts = []
+    if author:
+        parts.append(f"Created by {author}")
+    if desc:
+        parts.append(desc)
+
+    return ". ".join(parts) if parts else None
+
+
+def _infer_aim(signals: dict[str, Any]) -> str | None:
+    """Infer scenario aim from description and file name."""
+    desc = signals.get("header", {}).get("description", "")
+    fname = signals.get("file_name", "")
+
+    if desc and desc != fname:
+        return desc
+
+    # Try to make file name readable
+    readable = fname.replace("_", " ").replace("-", " ")
+    if readable and len(readable) > 3:
+        return f"Simulation of {readable} scenario"
+
+    return None
+
+
+def _infer_country(signals: dict[str, Any]) -> str | None:
+    """Infer country from various signals."""
+    author = signals.get("header", {}).get("author", "").lower()
+
+    # German institutions
+    if any(kw in author for kw in ["tu dresden", "vufo", "ika", "rwth", "vector"]):
+        return "DE"
+    # UK institutions
+    if any(kw in author for kw in ["wmg", "warwick", "coventry"]):
+        return "GB"
+
+    return None
+
+
+def _infer_movement_description(signals: dict[str, Any]) -> str | None:
+    """Summarize movement types from action analysis."""
+    actions = signals.get("action_types", [])
+    if not actions:
+        return None
+
+    movement_map = {
+        "SpeedAction": "speed changes",
+        "LaneChangeAction": "lane changes",
+        "TeleportAction": "position initialization",
+        "FollowTrajectoryAction": "trajectory following",
+        "AcquirePositionAction": "position acquisition",
+        "LongitudinalAction": "longitudinal motion",
+        "LateralAction": "lateral motion",
+        "RoutingAction": "route following",
+    }
+
+    movements = []
+    for action in actions:
+        clean = action.replace("Action", "").replace("action", "")
+        if action in movement_map:
+            movements.append(movement_map[action])
+        elif clean:
+            readable = re.sub(r"(?<!^)(?=[A-Z])", " ", clean).lower()
+            movements.append(readable)
+
+    if movements:
+        unique = list(dict.fromkeys(movements))
+        return ", ".join(unique[:5])
+
+    return None
+
+
+def _infer_criticality_factors(
+    signals: dict[str, Any], vocabulary: dict[str, Any]
+) -> list[str] | None:
+    """Infer criticality factors from scenario content."""
+    valid_values = set(
+        vocabulary.get("enums", {}).get("criticalityFactors", {}).get("values", [])
+    )
+    if not valid_values:
+        valid_values = {
+            "VRU_interaction",
+            "adverse_weather",
+            "high_relative_speed",
+            "infrastructure_violation",
+            "near_miss",
+            "occlusion",
+        }
+
+    factors = []
+
+    entities = set(signals.get("entity_types", []))
+    vru_types = {"pedestrian", "bicycle", "wheelchair"}
+    if entities & vru_types:
+        factors.append("VRU_interaction")
+
+    if signals.get("precipitation") or signals.get("fog_visual_range"):
+        fog_range = signals.get("fog_visual_range", "")
+        try:
+            if fog_range and float(fog_range) < 1000:
+                factors.append("adverse_weather")
+        except (ValueError, TypeError):
+            pass
+        precip = signals.get("precipitation", {})
+        try:
+            if (
+                precip.get("intensity", "0") != "0"
+                and float(precip.get("intensity", "0")) > 0
+            ):
+                factors.append("adverse_weather")
+        except (ValueError, TypeError):
+            pass
+
+    # High relative speed from scenario name/description clues
+    fname = signals.get("file_name", "").lower()
+    if any(kw in fname for kw in ["emergency", "braking", "deceleration", "aeb"]):
+        factors.append("high_relative_speed")
+
+    return [f for f in factors if f in valid_values] or None
+
+
+def _infer_weather(signals: dict[str, Any]) -> str | None:
+    """Infer weather summary from weather signals."""
+    if not signals.get("has_weather"):
+        return None
+
+    precip = signals.get("precipitation", {})
+    if precip.get("type") == "rain":
+        try:
+            if float(precip.get("intensity", "0")) > 0:
+                return "rain"
+        except (ValueError, TypeError):
+            pass
+    if precip.get("type") == "snow":
+        try:
+            if float(precip.get("intensity", "0")) > 0:
+                return "snow"
+        except (ValueError, TypeError):
+            pass
+
+    fog_range = signals.get("fog_visual_range", "")
+    if fog_range:
+        try:
+            if float(fog_range) < 500:
+                return "fog"
+        except (ValueError, TypeError):
+            pass
+
+    sun = signals.get("sun", {})
+    try:
+        if sun.get("elevation") and float(sun.get("elevation", "0")) < 0:
+            return "night"
+    except (ValueError, TypeError):
+        pass
+
+    cloud = signals.get("cloud_cover", "")
+    if cloud in WEATHER_MAP:
+        return WEATHER_MAP[cloud]
+
+    return "clear"
+
+
+def _infer_level_of_detail(signals: dict[str, Any]) -> list[str] | None:
+    """Infer HD map level of detail (object types present).
+
+    SHACL constrains this to e_objectType values for OpenDRIVE v1.5+.
+    """
+    # levelOfDetail in the ontology means "which object types are present"
+    # We can't reliably determine this without deep object analysis
+    return None
+
+
+def _infer_hdmap_source(signals: dict[str, Any]) -> str | None:
+    """Infer HD map data source."""
+    header = signals.get("header", {})
+    name = header.get("name", "").lower()
+
+    if "ncap" in name or "straight" in name:
+        return "Synthetic Generation"
+    if signals.get("geo_reference"):
+        return "Survey / Measurement"
+
+    return "Synthetic Generation"
+
+
+def _infer_hdmap_source_description(signals: dict[str, Any]) -> str | None:
+    """Build HD map source description."""
+    header = signals.get("header", {})
+    name = header.get("name", "")
+    if name:
+        return f"HD map: {name}"
+    return None

--- a/llm_enricher/main.py
+++ b/llm_enricher/main.py
@@ -1,0 +1,374 @@
+"""LLM enricher — main entry point.
+
+Usage:
+    # Evaluate all assets (no modification)
+    python -m llm_enricher evaluate examples/assets
+
+    # Enrich a single asset's metadata (writes enriched copy)
+    python -m llm_enricher enrich examples/assets/SCEN-95B774BAC0A9
+
+    # Pipeline integration (called by asset_extraction)
+    python -m llm_enricher enrich --output-path <path> --asset-type <type> <asset_dir>
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from .analyzer import analyze_asset
+from .enricher import enrich_hdmap, enrich_scenario
+from .vocabulary import extract_vocabulary
+
+logger = logging.getLogger(__name__)
+
+OMB_ARTIFACTS = Path("submodules/ontology-management-base/artifacts")
+
+
+def evaluate(assets_dir: Path) -> dict:
+    """Evaluate metadata completeness across all assets and estimate LLM enrichment impact."""
+    results = {"assets": {}, "summary": {}}
+    asset_folders = sorted(
+        [d for d in assets_dir.iterdir() if d.is_dir()],
+    )
+
+    for folder in asset_folders:
+        meta_dir = folder / "metadata"
+        if not meta_dir.exists():
+            continue
+
+        for meta_file in sorted(meta_dir.glob("*.json")):
+            if meta_file.suffix != ".json" or meta_file.name.endswith(".bjson"):
+                continue
+
+            asset_type = meta_file.stem  # "hdmap" or "scenario"
+            with open(meta_file) as f:
+                metadata = json.load(f)
+
+            # Find the source asset file
+            sim_dir = folder / "simulation-data"
+            source_file = _find_source_file(sim_dir, folder, asset_type)
+
+            if source_file:
+                signals = analyze_asset(source_file)
+            else:
+                signals = {"file_name": folder.name, "file_type": "unknown"}
+                logger.warning("No source file found for %s", folder.name)
+
+            # Load SHACL vocabulary
+            shacl_path = OMB_ARTIFACTS / asset_type / f"{asset_type}.shacl.ttl"
+            if shacl_path.exists():
+                vocabulary = extract_vocabulary(shacl_path)
+            else:
+                vocabulary = {"enums": {}, "properties": {}}
+                logger.warning("SHACL not found: %s", shacl_path)
+
+            # Get existing fields
+            prefix = asset_type
+            existing = _get_existing_fields(metadata, prefix)
+
+            # Run enrichment
+            if asset_type == "scenario":
+                enrichment = enrich_scenario(signals, existing, vocabulary)
+            else:
+                enrichment = enrich_hdmap(signals, existing, vocabulary)
+
+            asset_key = f"{folder.name}/{asset_type}"
+            results["assets"][asset_key] = {
+                "source_file": str(source_file) if source_file else None,
+                "existing_fields": list(existing.keys()),
+                "enriched_fields": enrichment["fields"],
+                "confidence": enrichment["confidence"],
+                "signals_used": {
+                    k: v
+                    for k, v in signals.items()
+                    if k not in ("parameters", "world_positions_sample", "action_types")
+                },
+            }
+
+    # Build summary
+    for asset_type in ["scenario", "hdmap"]:
+        type_assets = {
+            k: v for k, v in results["assets"].items() if k.endswith(f"/{asset_type}")
+        }
+        if not type_assets:
+            continue
+
+        field_fill_counts: dict[str, int] = {}
+        for asset_data in type_assets.values():
+            for field in asset_data["enriched_fields"]:
+                if asset_data["enriched_fields"][field] is not None:
+                    field_fill_counts[field] = field_fill_counts.get(field, 0) + 1
+
+        results["summary"][asset_type] = {
+            "total_assets": len(type_assets),
+            "fields_enriched": {
+                field: f"{count}/{len(type_assets)}"
+                for field, count in sorted(field_fill_counts.items())
+            },
+        }
+
+    return results
+
+
+def enrich_single(
+    asset_dir: Path,
+    asset_type: str | None = None,
+    output_path: Path | None = None,
+    source_dir: Path | None = None,
+) -> dict:
+    """Enrich metadata for a single asset.
+
+    Returns the enriched metadata dict with new fields merged in.
+    """
+    meta_dir = asset_dir / "metadata"
+
+    if asset_type is None:
+        # Auto-detect
+        if (meta_dir / "hdmap.json").exists():
+            asset_type = "hdmap"
+        elif (meta_dir / "scenario.json").exists():
+            asset_type = "scenario"
+        else:
+            raise FileNotFoundError(f"No metadata found in {meta_dir}")
+
+    meta_file = meta_dir / f"{asset_type}.json"
+    with open(meta_file) as f:
+        metadata = json.load(f)
+
+    # Find source file — check source_dir first (pipeline passes the original
+    # input directory), then fall back to simulation-data/ (post-processed assets)
+    source_file = None
+    if source_dir:
+        source_file = _find_source_file(source_dir, source_dir, asset_type)
+    if not source_file:
+        sim_dir = asset_dir / "simulation-data"
+        source_file = _find_source_file(sim_dir, asset_dir, asset_type)
+    signals = analyze_asset(source_file) if source_file else {}
+
+    # Load vocabulary
+    shacl_path = OMB_ARTIFACTS / asset_type / f"{asset_type}.shacl.ttl"
+    vocabulary = (
+        extract_vocabulary(shacl_path)
+        if shacl_path.exists()
+        else {"enums": {}, "properties": {}}
+    )
+
+    existing = _get_existing_fields(metadata, asset_type)
+
+    if asset_type == "scenario":
+        enrichment = enrich_scenario(signals, existing, vocabulary)
+    else:
+        enrichment = enrich_hdmap(signals, existing, vocabulary)
+
+    # Merge enriched fields into metadata
+    enriched_metadata = _merge_enrichment(metadata, enrichment["fields"], asset_type)
+
+    # Write output
+    if output_path:
+        out_file = output_path
+    else:
+        out_file = meta_dir / f"{asset_type}_enriched.json"
+
+    with open(out_file, "w") as f:
+        json.dump(enriched_metadata, f, indent=2, ensure_ascii=False)
+
+    logger.info(
+        "Enriched %d fields for %s → %s",
+        len(enrichment["fields"]),
+        asset_dir.name,
+        out_file,
+    )
+
+    return {
+        "enriched_fields": enrichment["fields"],
+        "confidence": enrichment["confidence"],
+        "output": str(out_file),
+    }
+
+
+def _find_source_file(sim_dir: Path, asset_dir: Path, asset_type: str) -> Path | None:
+    """Find the source simulation file."""
+    if sim_dir.exists():
+        ext = ".xodr" if asset_type == "hdmap" else ".xosc"
+        for f in sim_dir.glob(f"*{ext}"):
+            return f
+
+    # Fallback: search input directories
+    for pattern in ["**/*.xodr", "**/*.xosc"]:
+        ext_match = ".xodr" if asset_type == "hdmap" else ".xosc"
+        for f in asset_dir.glob(pattern):
+            if f.suffix == ext_match:
+                return f
+
+    return None
+
+
+def _get_existing_fields(metadata: dict, prefix: str) -> dict:
+    """Extract already-filled fields from metadata."""
+    domain_spec = metadata.get(f"{prefix}:hasDomainSpecification", {})
+    filled = {}
+
+    for section_key, section_data in domain_spec.items():
+        if section_key.startswith("@"):
+            continue
+        # Handle list sections (e.g. scenario:hasContent is [Content, Tag])
+        items = (
+            section_data
+            if isinstance(section_data, list)
+            else [section_data]
+            if isinstance(section_data, dict)
+            else []
+        )
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            for k, v in item.items():
+                if k.startswith("@"):
+                    continue
+                if v is not None and v != "" and v != [] and v != {}:
+                    filled[k] = v
+
+    return filled
+
+
+def _merge_enrichment(metadata: dict, enriched_fields: dict, prefix: str) -> dict:
+    """Merge enriched fields into the metadata JSON-LD structure."""
+    import copy
+
+    result = copy.deepcopy(metadata)
+    domain_spec = result.get(f"{prefix}:hasDomainSpecification", {})
+
+    # Field → section mapping
+    content_fields = {
+        "abstractionLevel",
+        "aim",
+        "controllers",
+        "country",
+        "criticalityFactors",
+        "customCommands",
+        "entityTypes",
+        "movementDescription",
+        "scenarioCategory",
+        "sunAzimuth",
+        "timeDate",
+        "usedStandardFunctions",
+        "weatherSummary",
+        "roadTypes",
+        "laneTypes",
+        "levelOfDetail",
+        "trafficDirection",
+    }
+    quantity_fields = {
+        "numberTrafficObjects",
+        "permanentTrafficObjects",
+        "temporaryTrafficObjects",
+    }
+    data_source_fields = {
+        "sourceType",
+        "sourceDescription",
+        "calibration",
+        "measurementSystem",
+        "usedDataSources",
+    }
+    quality_fields = {
+        "accuracyLaneModel2d",
+        "accuracyLaneModelHeight",
+        "accuracyObjects",
+        "accuracySignals",
+        "precision",
+        "rangeOfModeling",
+    }
+
+    section_map = {
+        f"{prefix}:hasContent": content_fields,
+        f"{prefix}:hasQuantity": quantity_fields,
+        f"{prefix}:hasDataSource": data_source_fields,
+        f"{prefix}:hasQuality": quality_fields,
+    }
+
+    for section_key, field_set in section_map.items():
+        raw_section = domain_spec.get(section_key, {})
+
+        # Handle list sections (e.g. scenario:hasContent can be a union list)
+        is_list = isinstance(raw_section, list)
+        if is_list:
+            # Find the primary content dict (matching the domain @type)
+            target_type = f"{prefix}:Content" if "Content" in section_key else None
+            section = None
+            for item in raw_section:
+                if isinstance(item, dict):
+                    if target_type and item.get("@type") == target_type:
+                        section = item
+                        break
+            if section is None and raw_section:
+                section = raw_section[0] if isinstance(raw_section[0], dict) else {}
+            if section is None:
+                section = {}
+        elif isinstance(raw_section, dict):
+            section = raw_section
+        else:
+            continue
+
+        has_new_fields = False
+        for field_name, value in enriched_fields.items():
+            if field_name in field_set and value is not None:
+                section[field_name] = value
+                has_new_fields = True
+
+        if has_new_fields:
+            if section_key not in domain_spec:
+                # Derive @type from section key (e.g. hdmap:hasDataSource → hdmap:DataSource)
+                type_name = section_key.split(":")[1].replace("has", "")
+                section["@type"] = f"{prefix}:{type_name}"
+                domain_spec[section_key] = section
+            elif not is_list:
+                # For dict sections, write back (list items are mutated in-place)
+                domain_spec[section_key] = section
+
+    return result
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(levelname)-7s %(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="LLM-based metadata enrichment for simulation assets"
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    eval_p = sub.add_parser("evaluate", help="Evaluate metadata completeness")
+    eval_p.add_argument("assets_dir", type=Path, help="Path to assets directory")
+
+    enrich_p = sub.add_parser("enrich", help="Enrich a single asset")
+    enrich_p.add_argument("asset_dir", type=Path, help="Path to asset directory")
+    enrich_p.add_argument("--asset-type", choices=["hdmap", "scenario"])
+    enrich_p.add_argument("--output-path", type=Path)
+    enrich_p.add_argument(
+        "--source-dir",
+        type=Path,
+        help="Directory containing the original source file (pipeline mode)",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "evaluate":
+        results = evaluate(args.assets_dir)
+        report_path = args.assets_dir / "enrichment_evaluation.json"
+        with open(report_path, "w") as f:
+            json.dump(results, f, indent=2, ensure_ascii=False)
+        print(json.dumps(results["summary"], indent=2))
+        print(f"\nFull report: {report_path}")
+    elif args.command == "enrich":
+        result = enrich_single(
+            args.asset_dir, args.asset_type, args.output_path, args.source_dir
+        )
+        print(json.dumps(result, indent=2))
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/llm_enricher/prompt_builder.py
+++ b/llm_enricher/prompt_builder.py
@@ -1,0 +1,138 @@
+"""Prompt builder for metadata enrichment.
+
+Builds a system prompt from SHACL vocabulary (following the
+ontology-based-nl-search pattern) that instructs the LLM to fill
+empty metadata fields based on asset analysis signals.
+"""
+
+from typing import Any
+
+PREAMBLE = """\
+# Metadata Enrichment Agent — Simulation Asset
+
+You are a metadata enrichment agent for ENVITED-X simulation assets.
+You receive analysis signals extracted from a simulation asset file
+and must fill missing metadata fields.
+
+## Rules
+1. Only fill fields you can determine with HIGH CONFIDENCE from the signals
+2. Use EXACTLY the valid values listed below for enum fields
+3. For string fields, provide concise, factual descriptions
+4. For fields you cannot determine, set the value to null
+5. Call `submit_metadata` with your filled fields
+"""
+
+
+def build_prompt(
+    vocabulary: dict[str, Any],
+    domain: str,
+    missing_fields: list[str],
+) -> str:
+    """Build LLM system prompt from SHACL vocabulary and missing fields.
+
+    Args:
+        vocabulary: Output from vocabulary.extract_vocabulary()
+        domain: "hdmap" or "scenario"
+        missing_fields: List of field names that need filling
+    """
+    sections = [PREAMBLE]
+
+    sections.append(f"\n## Domain: {domain}\n")
+
+    # Enum tables
+    enum_fields = [f for f in missing_fields if f in vocabulary["enums"]]
+    if enum_fields:
+        sections.append("### Enumeration Fields (use ONLY listed values)\n")
+        sections.append("| Field | Valid Values |")
+        sections.append("| ----- | ----------- |")
+        for field in sorted(enum_fields):
+            info = vocabulary["enums"][field]
+            vals = ", ".join(f"`{v}`" for v in info["values"])
+            desc = f" — {info['description'][:60]}" if info["description"] else ""
+            sections.append(f"| `{field}`{desc} | {vals} |")
+
+    # Non-enum fields
+    prop_fields = [
+        f
+        for f in missing_fields
+        if f not in vocabulary["enums"] and f in vocabulary["properties"]
+    ]
+    if prop_fields:
+        sections.append("\n### Data Fields\n")
+        sections.append("| Field | Type | Description |")
+        sections.append("| ----- | ---- | ----------- |")
+        for field in sorted(prop_fields):
+            info = vocabulary["properties"][field]
+            sections.append(
+                f"| `{field}` | {info['type']} | {info['description'][:80]} |"
+            )
+
+    sections.append("\n### Guidelines\n")
+    sections.append(
+        "- `scenarioCategory`: infer from maneuver names, action types, and scenario description"
+    )
+    sections.append("- `sourceType`: infer from author metadata and file provenance")
+    sections.append(
+        "- `criticalityFactors`: infer from entity interactions, weather, speeds"
+    )
+    sections.append(
+        "- `country`: infer from geo coordinates, author affiliation, or traffic rules"
+    )
+    sections.append("- `trafficDirection`: infer from road rule attribute (RHT/LHT)")
+    sections.append("- `aim`: derive from scenario name and description")
+    sections.append(
+        "- `movementDescription`: summarize the types of motion/actions in the scenario"
+    )
+
+    return "\n".join(sections)
+
+
+def build_tool_schema(
+    vocabulary: dict[str, Any],
+    missing_fields: list[str],
+) -> dict[str, Any]:
+    """Build the submit_metadata tool schema from vocabulary.
+
+    Returns a JSON Schema compatible dict for the tool's input.
+    """
+    properties: dict[str, Any] = {}
+
+    for field in missing_fields:
+        if field in vocabulary["enums"]:
+            info = vocabulary["enums"][field]
+            properties[field] = {
+                "type": ["string", "array", "null"],
+                "description": info.get("description", field),
+                "enum": info["values"] + [None],
+            }
+        elif field in vocabulary["properties"]:
+            info = vocabulary["properties"][field]
+            json_type = _xsd_to_json_type(info["type"])
+            properties[field] = {
+                "type": [json_type, "null"],
+                "description": info.get("description", field),
+            }
+        else:
+            properties[field] = {
+                "type": ["string", "null"],
+                "description": field,
+            }
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(properties.keys()),
+    }
+
+
+def _xsd_to_json_type(xsd_type: str) -> str:
+    """Convert XSD datatype to JSON Schema type."""
+    mapping = {
+        "string": "string",
+        "integer": "integer",
+        "float": "number",
+        "double": "number",
+        "dateTime": "string",
+        "boolean": "boolean",
+    }
+    return mapping.get(xsd_type, "string")

--- a/llm_enricher/vocabulary.py
+++ b/llm_enricher/vocabulary.py
@@ -1,0 +1,105 @@
+"""SHACL vocabulary extraction for LLM prompt construction.
+
+Reads SHACL shape files and extracts:
+- sh:in enumerations (valid values per property)
+- sh:datatype constraints (numeric/string types)
+- sh:name/sh:description (human-readable field documentation)
+
+This enables building LLM prompts dynamically from the ontology,
+following the pattern from ontology-based-nl-search/packages/ontology.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from rdflib import Graph, Namespace
+
+logger = logging.getLogger(__name__)
+
+SH = Namespace("http://www.w3.org/ns/shacl#")
+
+ENUM_QUERY = """
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT ?path ?name ?description ?value WHERE {
+    ?shape sh:property ?prop .
+    ?prop sh:path ?path .
+    OPTIONAL { ?prop sh:name ?name }
+    OPTIONAL { ?prop sh:description ?description }
+    ?prop sh:in ?list .
+    ?list rdf:rest*/rdf:first ?value .
+}
+ORDER BY ?path ?value
+"""
+
+PROPERTY_QUERY = """
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?path ?name ?description ?datatype ?minCount WHERE {
+    ?shape sh:property ?prop .
+    ?prop sh:path ?path .
+    OPTIONAL { ?prop sh:name ?name }
+    OPTIONAL { ?prop sh:description ?description }
+    OPTIONAL { ?prop sh:datatype ?datatype }
+    OPTIONAL { ?prop sh:minCount ?minCount }
+    FILTER NOT EXISTS { ?prop sh:in ?list }
+}
+ORDER BY ?path
+"""
+
+
+def extract_vocabulary(shacl_path: Path) -> dict[str, Any]:
+    """Extract vocabulary from a SHACL shape file.
+
+    Returns a dict with:
+        enums: {property_name: {values: [...], name: ..., description: ...}}
+        properties: {property_name: {type: ..., name: ..., description: ..., required: bool}}
+    """
+    g = Graph()
+    g.parse(str(shacl_path), format="turtle")
+
+    vocab: dict[str, Any] = {"enums": {}, "properties": {}}
+
+    for row in g.query(ENUM_QUERY):
+        prop = _local_name(str(row.path))
+        if prop not in vocab["enums"]:
+            vocab["enums"][prop] = {
+                "values": [],
+                "name": str(row.name) if row.name else prop,
+                "description": str(row.description) if row.description else "",
+            }
+        vocab["enums"][prop]["values"].append(str(row.value))
+
+    for row in g.query(PROPERTY_QUERY):
+        prop = _local_name(str(row.path))
+        if prop.startswith("has") or prop.startswith("ndb"):
+            continue
+        dt = _local_name(str(row.datatype)) if row.datatype else "string"
+        required = bool(row.minCount and int(row.minCount) > 0)
+        vocab["properties"][prop] = {
+            "type": dt,
+            "name": str(row.name) if row.name else prop,
+            "description": str(row.description) if row.description else "",
+            "required": required,
+        }
+
+    logger.info(
+        "Extracted vocabulary: %d enums, %d properties from %s",
+        len(vocab["enums"]),
+        len(vocab["properties"]),
+        shacl_path.name,
+    )
+    return vocab
+
+
+def _local_name(uri: str) -> str:
+    """Extract local name from a URI."""
+    for sep in ("#", "/"):
+        if sep in uri:
+            return uri.rsplit(sep, 1)[-1]
+    return uri


### PR DESCRIPTION
## Summary

Add `llm_enricher/` module that fills empty metadata fields by analyzing source simulation files (OpenDRIVE/OpenSCENARIO XML) against SHACL vocabulary constraints. Disabled by default — opt-in via `process.json`.

## Motivation

Metadata completeness analysis across all 25 output assets revealed:
- **Scenario assets (24)**: only 23.4% of SHACL fields filled on average
- **HD Map assets (1)**: 52.2% of SHACL fields filled

Many empty fields (scenarioCategory, sourceType, aim, criticalityFactors, etc.) can be inferred from the source simulation files without manual input.

## Architecture

```
llm_enricher/
├── analyzer.py       # XML signal extraction from .xodr/.xosc
├── vocabulary.py     # SHACL vocabulary extraction via rdflib SPARQL
├── enricher.py       # Rule-based field filling with confidence levels
├── prompt_builder.py # SHACL→prompt construction (future LLM integration)
└── main.py           # CLI entry point + pipeline integration
```

### Module Design

1. **Signal extraction** (`analyzer.py`): Parses source XML to extract metadata signals — header info, entity types, maneuver actions, weather parameters, road types, traffic rules
2. **Vocabulary loading** (`vocabulary.py`): Extracts valid enum values and property constraints from SHACL shapes via SPARQL queries
3. **Rule-based enrichment** (`enricher.py`): Maps signals to metadata fields using keyword matching, heuristics, and enum validation. All output values are validated against `sh:in` constraints before writing
4. **Merge logic** (`main.py`): Safely merges enriched fields into existing JSON-LD metadata, handling list sections (e.g. `scenario:hasContent` which contains `[Content, Tag]`)

### Enrichable Fields

**Scenario**: scenarioCategory, sourceType, sourceDescription, aim, country, movementDescription, criticalityFactors, weatherSummary, controllers, customCommands, permanentTrafficObjects, temporaryTrafficObjects

**HD Map**: trafficDirection, levelOfDetail, usedDataSources, sourceDescription

### Confidence Levels

- **high**: directly extractable from file (trafficDirection from RHT/LHT rules, controllers from Controller elements)
- **medium**: inferred via heuristics (scenarioCategory from maneuver keywords, sourceType from author metadata)
- **low**: educated guesses (temporaryTrafficObjects=0)

## Pipeline Integration

- Runs **after** wizard_caller (step 7), **before** SHACL validation (step 8)
- **Disabled by default** (`enable: false` in `process.json`)
- Uses `--source-dir` to access original input files (since `simulation-data/` is not yet created at this pipeline stage)
- Config: `configs/config_llm_enricher.json`

## Evaluation Results

Run on all 25 existing assets:

| Metric | Scenario (24 assets) | HD Map (1 asset) |
|--------|---------------------|------------------|
| Fields enrichable | aim (24/24), movementDescription (24/24), sourceDescription (24/24), scenarioCategory (11/24), sourceType (17/24), country (17/24), weatherSummary (11/24), criticalityFactors (8/24) | usedDataSources (1/1), sourceDescription (1/1) |

## Research: ontology-based-nl-search

Analyzed [ASCS-eV/ontology-based-nl-search](https://github.com/ASCS-eV/ontology-based-nl-search) for integration patterns:
- It is a **search-only** tool (NL query → SPARQL), not metadata enrichment
- Key reusable pattern: SHACL vocabulary → dynamic prompt construction via SPARQL queries
- This pattern is implemented in `vocabulary.py` and `prompt_builder.py` for future LLM-based enrichment
- The `prompt_builder.py` module prepares structured prompts from SHACL shapes that could be used with Vercel AI SDK or similar LLM frameworks

## Testing

- ✅ Scenario pipeline with enricher enabled passes SHACL validation
- ✅ HD Map pipeline with enricher enabled passes SHACL validation
- ✅ All enriched enum values validated against SHACL `sh:in` constraints
- ✅ Float conversion errors handled (OpenSCENARIO parameter references like `$sun_elevation`)
- ✅ `ruff check` passes on all module files

## CLI Usage

```bash
# Evaluate metadata completeness across all assets
python -m llm_enricher evaluate examples/assets

# Enrich a single processed asset
python -m llm_enricher enrich examples/assets/SCEN-95B774BAC0A9

# Pipeline mode (called automatically when enabled)
python -m llm_enricher enrich <asset_dir> --output-path <path> --asset-type scenario --source-dir <input_dir>
```