### PR TITLE
feat(wizard): provenance-aware verification flow with pipeline integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,35 +236,30 @@ ifneq ($(INPUT_DIR),)
 		$(if $(ZIP_DIR),-zip-dir "$(ZIP_DIR)") \
 		$(PIPELINE_FLAGS)
 	@echo "[OK] Pipeline complete -> $(OUTPUT_DIR)"
+else ifeq ($(SUBCMD),batch)
+	@echo "[INFO] Batch-processing all input manifests under examples/..."
+	@mkdir -p "$(OUTPUT_DIR)" 2>/dev/null || true
+	@rm -f "$(OUTPUT_DIR)/.asset_registry.json"
+	@"$(PYTHON)" -m batch_runner batch \
+		"$(CURDIR)/examples" \
+		-config "$(CURDIR)/configs" \
+		-out "$(OUTPUT_DIR)" \
+		-zip-dir "$(ASSETS_DIR)" \
+		$(PIPELINE_FLAGS)
+	@echo "[OK] Batch complete -> $(OUTPUT_DIR)"
 else
 	@dir="$(EXAMPLE_$(SUBCMD))"; \
 	if [ -z "$$dir" ]; then \
 		echo "[ERR] Unknown example: $(SUBCMD)"; \
-		echo "Usage:  make $@ <opendrive|openscenario>"; \
+		echo "Usage:  make $@ <opendrive|openscenario|batch>"; \
 		echo "        make $@ INPUT_DIR=path/to/input OUTPUT_DIR=path/to/output"; \
 		exit 1; \
 	fi; \
-	bak="$(CURDIR)/examples/$$dir/input_manifest.json.bak"; \
 	status=0; \
-	restore_status=0; \
 	if [ "$(SUBCMD)" = "openscenario" ]; then \
-		odr_manifest=$$(find "$(ASSETS_DIR)" -name manifest.json 2>/dev/null | head -1); \
-		if [ -z "$$odr_manifest" ]; then \
+		if [ ! -f "$(ASSETS_DIR)/.asset_registry.json" ]; then \
 			echo "[INFO] OpenScenario references an OpenDRIVE map -- building dependency first..."; \
 			"$(MAKE)" generate opendrive || status=$$?; \
-			if [ $$status -eq 0 ]; then \
-				odr_manifest=$$(find "$(ASSETS_DIR)" -name manifest.json 2>/dev/null | head -1); \
-			fi; \
-		fi; \
-		if [ $$status -eq 0 ] && [ -n "$$odr_manifest" ]; then \
-			echo "[INFO] Resolving external references from $$odr_manifest"; \
-			cp "$(CURDIR)/examples/$$dir/input_manifest.json" \
-			   "$$bak" || status=$$?; \
-			if [ $$status -eq 0 ]; then \
-				"$(CURDIR)/$(PYTHON)" "$(CURDIR)/scripts/resolve_references.py" \
-					"$(CURDIR)/examples/$$dir/input_manifest.json" \
-					--ref-manifest "$$odr_manifest" || status=$$?; \
-			fi; \
 		fi; \
 	fi; \
 	if [ $$status -eq 0 ]; then \
@@ -276,21 +271,25 @@ else
 			-zip-dir "$(ASSETS_DIR)" \
 			$(PIPELINE_FLAGS) || status=$$?; \
 	fi; \
-	if [ -f "$$bak" ]; then \
-		mv "$$bak" "$(CURDIR)/examples/$$dir/input_manifest.json" || restore_status=$$?; \
-	fi; \
-	if [ $$restore_status -ne 0 ]; then \
-		echo "[ERR] Failed to restore input manifest"; \
-		if [ $$status -eq 0 ]; then \
-			status=$$restore_status; \
-		fi; \
-	fi; \
 	if [ $$status -ne 0 ]; then \
 		echo "[ERR] $$dir pipeline failed (exit $$status)"; \
 		exit $$status; \
 	fi; \
 	echo "[OK] $$dir pipeline complete"
 endif
+
+# ── Review (interactive metadata review) ─────────────────────────────
+
+REVIEW_DIR ?= $(ASSETS_DIR)
+
+review:
+	$(call check_dev_setup)
+	@echo "[INFO] Reviewing assets under $(REVIEW_DIR)..."
+	@WIZARD_ENABLED=true "$(PYTHON)" -m batch_runner review \
+		"$(REVIEW_DIR)" \
+		-config "$(CURDIR)/configs" \
+		-zip-dir "$(REVIEW_DIR)"
+	@echo "[OK] Review complete"
 
 # ── Wizard (SD Creation Wizard API) ──────────────────────────────────
 
@@ -384,6 +383,7 @@ help:
 	@echo ""
 	@echo "  make generate opendrive      Run OpenDRIVE example pipeline"
 	@echo "  make generate openscenario   Run OpenSCENARIO example pipeline"
+	@echo "  make generate batch          Batch-process all examples (hdmap first, then scenario)"
 	@echo "  make generate INPUT_DIR=<path> OUTPUT_DIR=<path>"
 	@echo "                               Run pipeline for a custom input directory"
 	@echo ""
@@ -408,6 +408,14 @@ help:
 	@echo "  make wizard stop             Stop the wizard API"
 	@echo "  make setup wizard            Reinstall wizard dependencies only"
 	@echo ""
+	@echo "Metadata review (interactive — enriches, reviews, and re-zips):"
+	@echo "  make review                  Review all assets in examples/assets/ via wizard"
+	@echo "  make review REVIEW_DIR=<path>"
+	@echo "                               Review assets in a custom directory"
+	@echo ""
+	@echo "  validate = automated SHACL conformance check (read-only, pass/fail)"
+	@echo "  review   = interactive human review via wizard (may enrich and re-zip)"
+	@echo ""
 	@echo "  make clean                   Remove build artifacts and caches"
 	@echo "  make clean all               Clean + remove venv and submodules (full reset)"
 	@echo ""
@@ -421,7 +429,7 @@ help:
 
 # ── Catch-all for subcommand arguments ───────────────────────────────
 # Prevents "No rule to make target 'opendrive'" errors
-ifneq ($(filter setup generate check wizard clean,$(firstword $(MAKECMDGOALS))),)
+ifneq ($(filter setup generate check wizard clean review,$(firstword $(MAKECMDGOALS))),)
 %:
 	@:
 endif

--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ make generate opendrive      # OpenDRIVE example  → examples/assets/
 make generate openscenario   # OpenSCENARIO example → examples/assets/
 ```
 
+### Batch Processing
+
+Process all input manifests under the `examples/` directory tree in a single
+command.  HD-map inputs are processed before scenarios so cross-references
+resolve correctly:
+
+```bash
+make generate batch
+```
+
 ### Selective Module Execution
 
 Individual pipeline modules can be enabled or disabled at runtime using the
@@ -280,6 +290,27 @@ Ports are configurable via `.env` (see `.env.example`):
 WIZARD_API_PORT=3007
 WIZARD_FRONTEND_PORT=5174
 ```
+
+## Metadata Review
+
+Review existing generated assets interactively.  `make review` enriches
+metadata with `llm_enricher`, opens the wizard for human verification, and
+re-zips any assets whose metadata changed:
+
+```bash
+make review                            # review all assets in examples/assets/
+make review REVIEW_DIR=path/to/assets  # review assets in a custom directory
+```
+
+### How It Differs from Validate
+
+| Command | Purpose | Automated | Modifies assets |
+|---------|---------|-----------|-----------------|
+| `make validate` | SHACL schema conformance check | Yes (read-only) | No |
+| `make review` | Human metadata review via wizard | Interactive | Yes (re-zips on change) |
+
+Use `validate` to verify structural correctness.  Use `review` to verify
+semantic completeness and accuracy with a human in the loop.
 
 ## Notes
 

--- a/asset_extraction/main.py
+++ b/asset_extraction/main.py
@@ -10,6 +10,12 @@ from utils.pipeline_reporting import (
     summarize_stage_failure,
     summarize_stage_success,
 )
+from utils.asset_registry import (
+    has_collision,
+    load_registry,
+    register_asset,
+    resolve_placeholders,
+)
 from utils.cid import compute_file_cid
 from utils.http import download_or_get_file, is_url
 from utils.json import write_json
@@ -559,6 +565,9 @@ def main():
     if not asset_file.exists():
         raise FileNotFoundError(f"asset file {asset_file} not exists")
 
+    asset_type_ext = get_asset_type_extension(asset_file)
+    asset_type = get_asset_type(asset_type_ext)
+
     # load all configs that are applicable to the asset type
     if not config_dir.is_dir():
         raise FileNotFoundError(f"config path {config_dir} not exists")
@@ -573,7 +582,13 @@ def main():
     asset_name = asset_file.stem
     _validate_asset_name(asset_name)
 
-    output_sub_dir = output_dir / asset_name
+    # Collision avoidance: if a different asset type already occupies this
+    # stem in the registry (e.g. hdmap "Foo.xodr" vs scenario "Foo.xosc"),
+    # disambiguate by appending the asset type.
+    if has_collision(output_dir, asset_name, asset_type):
+        output_sub_dir = output_dir / f"{asset_name}_{asset_type}"
+    else:
+        output_sub_dir = output_dir / asset_name
     if output_sub_dir.exists():
         shutil.rmtree(output_sub_dir)
     output_sub_dir.mkdir(parents=True, exist_ok=True)
@@ -663,6 +678,8 @@ def main():
             refs.extend(auto_refs)
 
     if refs and manifest_path.exists():
+        # Resolve __*__ placeholders from the asset registry before writing
+        resolve_placeholders(refs, output_dir, current_stem=asset_name)
         with manifest_path.open("r", encoding="utf-8") as f:
             manifest = json.load(f)
         manifest["hasReferencedArtifacts"] = [_format_reference(ref) for ref in refs]
@@ -686,6 +703,25 @@ def main():
     temp_zip_path.replace(zip_filename)
     archive_display = zip_filename
     logger.info("[DONE ] Archive: %s", archive_display)
+
+    # Register the asset so later pipeline runs can resolve cross-references
+    sim_data_files = (
+        list((output_sub_dir / "simulation-data").glob("*"))
+        if (output_sub_dir / "simulation-data").is_dir()
+        else []
+    )
+    sim_data_path = (
+        f"simulation-data/{sim_data_files[0].name}" if sim_data_files else ""
+    )
+    register_asset(
+        output_dir,
+        stem=asset_name,
+        asset_type=asset_type,
+        cid=archive_cid,
+        manifest_path=str(manifest_path.relative_to(output_dir)),
+        sim_data_path=sim_data_path,
+    )
+
     pipeline_reporter.finish_pipeline(perf_counter() - pipeline_started_at)
 
 

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1,0 +1,551 @@
+"""Batch runner — process multiple assets or review existing ones.
+
+Subcommands
+-----------
+batch
+    Discover all ``input_manifest.json`` files under a directory tree and run
+    the full asset-extraction pipeline for each.  HD-map inputs are processed
+    before scenario inputs so cross-references resolve correctly.
+
+review
+    Enrich and interactively review metadata for existing asset folders via
+    the SD Creation Wizard queue UI, then re-zip any assets whose metadata
+    changed.
+
+Usage::
+
+    # Batch-process all examples
+    python -m batch_runner batch examples/
+
+    # Review existing assets
+    python -m batch_runner review examples/assets/
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import shutil
+import sys
+from pathlib import Path
+from zipfile import ZipFile, ZipInfo
+
+from utils.cid import compute_file_cid
+from utils.log_config import is_debug_logging, setup_logging
+from utils.subprocess import run_command, CommandError
+
+setup_logging(logging.DEBUG if is_debug_logging() else logging.INFO)
+logger = logging.getLogger(__name__)
+
+# HD-map inputs must be processed before scenario inputs so that cross-
+# references (e.g. OpenSCENARIO → OpenDRIVE) resolve correctly.
+_TYPE_ORDER = {"hdmap": 0, "scenario": 1}
+
+
+# ── Batch subcommand ─────────────────────────────────────────────────
+
+
+def _sort_key(p: Path) -> tuple[int, str]:
+    parent = p.parent.name.lower()
+    order = _TYPE_ORDER.get(parent, 99)
+    return (order, str(p))
+
+
+def _discover_manifests(root: Path) -> list[Path]:
+    """Find all ``input_manifest.json`` files under *root*, sorted hdmap-first."""
+    return sorted(root.rglob("input_manifest.json"), key=_sort_key)
+
+
+def run_batch(
+    input_dir: Path,
+    config_dir: Path,
+    output_dir: Path,
+    zip_dir: Path | None = None,
+    pipeline_flags: list[str] | None = None,
+) -> dict[str, bool]:
+    """Run the pipeline for every ``input_manifest.json`` under *input_dir*.
+
+    Returns a dict mapping manifest path → success boolean.
+    """
+    manifests = _discover_manifests(input_dir)
+    if not manifests:
+        logger.warning("No input_manifest.json files found under %s", input_dir)
+        return {}
+
+    logger.info(
+        "Batch: discovered %d input manifest(s) under %s", len(manifests), input_dir
+    )
+
+    results: dict[str, bool] = {}
+    for idx, manifest in enumerate(manifests, 1):
+        label = str(manifest.relative_to(input_dir))
+        logger.info("━━ [%d/%d] %s", idx, len(manifests), label)
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "asset_extraction.main",
+            str(manifest),
+            "-config",
+            str(config_dir),
+            "-out",
+            str(output_dir),
+        ]
+        if zip_dir:
+            cmd += ["-zip-dir", str(zip_dir)]
+        if pipeline_flags:
+            cmd += pipeline_flags
+
+        try:
+            run_command(
+                cmd=cmd,
+                name=f"pipeline({label})",
+                cwd=str(Path(__file__).parent),
+                log_output=False,
+            )
+            results[label] = True
+            logger.info("━━ [%d/%d] %s ✓", idx, len(manifests), label)
+        except CommandError:
+            results[label] = False
+            logger.error("━━ [%d/%d] %s ✗", idx, len(manifests), label)
+
+    succeeded = sum(1 for v in results.values() if v)
+    failed = len(results) - succeeded
+    logger.info(
+        "Batch complete: %d succeeded, %d failed out of %d",
+        succeeded,
+        failed,
+        len(results),
+    )
+    return results
+
+
+# ── Review subcommand ────────────────────────────────────────────────
+
+
+def _discover_asset_dirs(root: Path) -> list[Path]:
+    """Find asset directories (contain ``manifest.json``) under *root*."""
+    dirs = []
+    for manifest in sorted(root.rglob("manifest.json")):
+        asset_dir = manifest.parent
+        # Must have metadata/ to be a valid asset dir
+        if (asset_dir / "metadata").is_dir():
+            dirs.append(asset_dir)
+    return dirs
+
+
+def _hash_file(path: Path) -> str:
+    """Return SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _hash_metadata_dir(metadata_dir: Path) -> str:
+    """Return a combined hash of all JSON files in a metadata directory."""
+    h = hashlib.sha256()
+    for json_file in sorted(metadata_dir.glob("*.json")):
+        h.update(json_file.name.encode())
+        h.update(_hash_file(json_file).encode())
+    return h.hexdigest()
+
+
+def _create_zip(output_dir: Path, zip_path: Path) -> None:
+    """Create a deterministic zip archive of *output_dir*."""
+    source_mtime = os.environ.get("SL58_SOURCE_MTIME")
+    if source_mtime:
+        from datetime import datetime
+
+        dt = datetime.fromtimestamp(int(source_mtime))
+        fixed_date_time = (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
+    else:
+        fixed_date_time = None
+
+    with ZipFile(zip_path, "w") as zipf:
+        for file_path in sorted(output_dir.rglob("*")):
+            if file_path.is_file():
+                file_local = file_path.relative_to(output_dir)
+                if fixed_date_time:
+                    info = ZipInfo(file_local.as_posix(), date_time=fixed_date_time)
+                    info.compress_type = zipf.compression
+                    zipf.writestr(info, file_path.read_bytes())
+                else:
+                    zipf.write(file_path, file_local)
+
+
+def _rezip_asset(asset_dir: Path, zip_dir: Path) -> Path | None:
+    """Re-create the CID.zip for a single asset directory.
+
+    Returns the new zip path, or None on error.
+    """
+    temp_zip = zip_dir / "asset.zip"
+    if temp_zip.exists():
+        temp_zip.unlink()
+
+    _create_zip(asset_dir, temp_zip)
+    archive_cid = compute_file_cid(temp_zip)
+    zip_filename = zip_dir / f"{archive_cid}.zip"
+
+    if zip_filename.exists():
+        zip_filename.unlink()
+    temp_zip.replace(zip_filename)
+
+    logger.info("Re-zipped %s → %s", asset_dir.name, zip_filename.name)
+    return zip_filename
+
+
+def run_review(
+    assets_dir: Path,
+    config_dir: Path,
+    zip_dir: Path | None = None,
+) -> dict[str, str]:
+    """Enrich, review, and optionally re-zip assets under *assets_dir*.
+
+    Returns a dict mapping asset name → status (enriched/unchanged/error).
+    """
+    asset_dirs = _discover_asset_dirs(assets_dir)
+    if not asset_dirs:
+        logger.warning("No asset directories found under %s", assets_dir)
+        return {}
+
+    effective_zip_dir = zip_dir or assets_dir
+    logger.info("Review: discovered %d asset(s) under %s", len(asset_dirs), assets_dir)
+
+    # Snapshot metadata hashes before enrichment
+    pre_hashes: dict[str, str] = {}
+    for asset_dir in asset_dirs:
+        meta_dir = asset_dir / "metadata"
+        pre_hashes[asset_dir.name] = _hash_metadata_dir(meta_dir)
+
+    # Phase 1: Enrich all assets
+    logger.info("Phase 1: Enriching metadata for %d assets...", len(asset_dirs))
+    for idx, asset_dir in enumerate(asset_dirs, 1):
+        logger.info("  [%d/%d] Enriching %s", idx, len(asset_dirs), asset_dir.name)
+        _enrich_asset(asset_dir, config_dir)
+
+    # Phase 2: Wizard review (queue mode)
+    logger.info("Phase 2: Opening wizard for interactive review...")
+    _run_wizard_queue(asset_dirs, config_dir)
+
+    # Phase 3: Detect changes and re-zip
+    logger.info("Phase 3: Checking for changes and re-zipping...")
+    results: dict[str, str] = {}
+    for asset_dir in asset_dirs:
+        meta_dir = asset_dir / "metadata"
+        post_hash = _hash_metadata_dir(meta_dir)
+
+        if post_hash != pre_hashes[asset_dir.name]:
+            logger.info("  %s: metadata changed — re-zipping", asset_dir.name)
+            new_zip = _rezip_asset(asset_dir, effective_zip_dir)
+            results[asset_dir.name] = (
+                f"updated → {new_zip.name}" if new_zip else "error"
+            )
+        else:
+            logger.info("  %s: unchanged", asset_dir.name)
+            results[asset_dir.name] = "unchanged"
+
+    changed = sum(1 for v in results.values() if v.startswith("updated"))
+    logger.info(
+        "Review complete: %d changed, %d unchanged out of %d",
+        changed,
+        len(results) - changed,
+        len(results),
+    )
+    return results
+
+
+def _enrich_asset(asset_dir: Path, config_dir: Path) -> None:
+    """Run llm_enricher on a single asset directory."""
+    # Detect asset type from metadata
+    meta_dir = asset_dir / "metadata"
+    asset_type = None
+    for candidate in ("hdmap", "scenario", "environment-model"):
+        if (meta_dir / f"{candidate}.json").exists():
+            asset_type = candidate
+            break
+
+    if not asset_type:
+        logger.warning(
+            "Cannot detect asset type for %s — skipping enrichment", asset_dir.name
+        )
+        return
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "llm_enricher.main",
+        "enrich",
+        str(asset_dir),
+        "--asset-type",
+        asset_type,
+        "--output-path",
+        str(meta_dir / f"{asset_type}.json"),
+    ]
+    try:
+        run_command(
+            cmd=cmd,
+            name=f"enrich({asset_dir.name})",
+            cwd=str(Path(__file__).parent),
+            log_output=False,
+        )
+    except CommandError:
+        logger.warning("Enrichment failed for %s — continuing", asset_dir.name)
+
+
+def _run_wizard_queue(asset_dirs: list[Path], config_dir: Path) -> None:
+    """Open the wizard with a queue of all assets for interactive review.
+
+    Falls back to per-asset wizard if queue API is not available.
+    """
+    if not os.environ.get("WIZARD_ENABLED", "").lower() == "true":
+        logger.info(
+            "Wizard not enabled (set WIZARD=true) — skipping interactive review"
+        )
+        return
+
+    from wizard_caller.api_client import (
+        WizardAPIError,
+        ensure_wizard_running,
+        open_wizard_browser,
+    )
+
+    api_url = os.environ.get("WIZARD_API_URL") or "http://localhost:3007"
+    resolved_url = ensure_wizard_running(api_url)
+    if not resolved_url:
+        logger.warning("Wizard API not available — skipping interactive review")
+        return
+
+    # Try queue mode first (POST /session/queue)
+    if _try_queue_mode(resolved_url, asset_dirs, config_dir):
+        return
+
+    # Fallback: process one at a time
+    logger.info("Queue API not available — falling back to per-asset wizard")
+    for idx, asset_dir in enumerate(asset_dirs, 1):
+        meta_dir = asset_dir / "metadata"
+        asset_type = _detect_asset_type(meta_dir)
+        if not asset_type:
+            continue
+
+        shacl_path = (
+            Path("submodules/ontology-management-base/artifacts")
+            / asset_type
+            / f"{asset_type}.shacl.ttl"
+        )
+        jsonld_path = meta_dir / f"{asset_type}.json"
+        provenance_path = meta_dir / f"{asset_type}_provenance.json"
+
+        if not shacl_path.exists() or not jsonld_path.exists():
+            continue
+
+        logger.info("  [%d/%d] Reviewing %s", idx, len(asset_dirs), asset_dir.name)
+        try:
+            open_wizard_browser(
+                api_url=resolved_url,
+                shacl_path=shacl_path,
+                jsonld_path=jsonld_path,
+                output_path=jsonld_path,
+                provenance_path=provenance_path if provenance_path.exists() else None,
+                asset_name=asset_dir.name,
+            )
+        except WizardAPIError as exc:
+            logger.warning("Wizard failed for %s: %s", asset_dir.name, exc)
+
+
+def _try_queue_mode(api_url: str, asset_dirs: list[Path], config_dir: Path) -> bool:
+    """Attempt to use the batch queue API. Returns True if successful."""
+    import requests
+    import webbrowser
+
+    queue_url = f"{api_url.rstrip('/')}/session/queue"
+
+    sessions = []
+    for asset_dir in asset_dirs:
+        meta_dir = asset_dir / "metadata"
+        asset_type = _detect_asset_type(meta_dir)
+        if not asset_type:
+            continue
+
+        shacl_path = (
+            Path("submodules/ontology-management-base/artifacts")
+            / asset_type
+            / f"{asset_type}.shacl.ttl"
+        )
+        jsonld_path = meta_dir / f"{asset_type}.json"
+        provenance_path = meta_dir / f"{asset_type}_provenance.json"
+
+        if not shacl_path.exists() or not jsonld_path.exists():
+            continue
+
+        session_data: dict = {
+            "assetName": asset_dir.name,
+            "assetType": asset_type,
+            "outputPath": str(jsonld_path.resolve()),
+        }
+
+        # Read file contents for the queue payload
+        session_data["shaclContent"] = shacl_path.read_text(encoding="utf-8")
+        session_data["jsonLdContent"] = jsonld_path.read_text(encoding="utf-8")
+        if provenance_path.exists():
+            session_data["provenanceContent"] = provenance_path.read_text(
+                encoding="utf-8"
+            )
+
+        sessions.append(session_data)
+
+    if not sessions:
+        return False
+
+    try:
+        resp = requests.post(queue_url, json={"sessions": sessions}, timeout=30)
+        if resp.status_code != 200:
+            logger.debug("Queue API returned %d — not available", resp.status_code)
+            return False
+    except (requests.ConnectionError, requests.Timeout):
+        return False
+
+    logger.info("Created wizard queue with %d sessions", len(sessions))
+
+    frontend_url = os.environ.get("WIZARD_FRONTEND_URL") or "http://localhost:5174"
+    webbrowser.open(frontend_url)
+
+    logger.info(
+        "Waiting for you to review all assets in the browser...\n"
+        "  → Review each asset and click 'Export' or 'Next' to proceed.\n"
+        "  → The pipeline will continue when all assets are reviewed."
+    )
+
+    # Poll queue status
+    status_url = f"{api_url.rstrip('/')}/session/queue/status"
+    import time
+
+    timeout = 3600  # 1 hour for batch review
+    elapsed = 0
+    poll_interval = 3
+
+    while elapsed < timeout:
+        try:
+            resp = requests.get(status_url, timeout=5)
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("allExported"):
+                    logger.info("All %d assets reviewed ✓", len(sessions))
+                    return True
+                current = data.get("current", 0) + 1
+                total = data.get("total", len(sessions))
+                completed = data.get("completed", 0)
+                logger.debug(
+                    "Queue progress: %d/%d (completed: %d)", current, total, completed
+                )
+        except (requests.ConnectionError, requests.Timeout):
+            pass
+
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+
+    logger.warning("Wizard queue timed out after %ds", timeout)
+    return True  # Still consider it done — user may have exported some
+
+
+def _detect_asset_type(meta_dir: Path) -> str | None:
+    """Detect asset type from files in metadata directory."""
+    for candidate in ("hdmap", "scenario", "environment-model"):
+        if (meta_dir / f"{candidate}.json").exists():
+            return candidate
+    return None
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="batch_runner",
+        description="Batch-process or review multiple assets",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # batch subcommand
+    batch_parser = subparsers.add_parser(
+        "batch",
+        help="Run pipeline for all input manifests under a directory",
+    )
+    batch_parser.add_argument(
+        "input_dir",
+        type=str,
+        help="Root directory to search for input_manifest.json files",
+    )
+    batch_parser.add_argument(
+        "-config",
+        type=str,
+        default="configs",
+        help="Config directory (default: configs)",
+    )
+    batch_parser.add_argument(
+        "-out",
+        type=str,
+        default="examples/assets",
+        help="Output directory for generated assets",
+    )
+    batch_parser.add_argument(
+        "-zip-dir",
+        type=str,
+        default=None,
+        help="Output directory for CID.zip archives (default: same as -out)",
+    )
+    batch_parser.add_argument(
+        "pipeline_flags",
+        nargs="*",
+        default=[],
+        help="Additional flags passed to asset_extraction.main",
+    )
+
+    # review subcommand
+    review_parser = subparsers.add_parser(
+        "review",
+        help="Enrich and review existing assets via wizard",
+    )
+    review_parser.add_argument(
+        "assets_dir",
+        type=str,
+        help="Directory containing generated asset folders",
+    )
+    review_parser.add_argument(
+        "-config",
+        type=str,
+        default="configs",
+        help="Config directory (default: configs)",
+    )
+    review_parser.add_argument(
+        "-zip-dir",
+        type=str,
+        default=None,
+        help="Output directory for re-generated CID.zip archives",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "batch":
+        results = run_batch(
+            input_dir=Path(args.input_dir).resolve(),
+            config_dir=Path(args.config).resolve(),
+            output_dir=Path(args.out).resolve(),
+            zip_dir=Path(args.zip_dir).resolve() if args.zip_dir else None,
+            pipeline_flags=args.pipeline_flags or None,
+        )
+        if any(not v for v in results.values()):
+            sys.exit(1)
+
+    elif args.command == "review":
+        results = run_review(
+            assets_dir=Path(args.assets_dir).resolve(),
+            config_dir=Path(args.config).resolve(),
+            zip_dir=Path(args.zip_dir).resolve() if args.zip_dir else None,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/configs/config_wizard_caller.json
+++ b/configs/config_wizard_caller.json
@@ -8,7 +8,8 @@
 		"output" : {"-out" : "{path}/{sub_path}/{asset_type}.json"},
 		"additional" : {			
 			"-shacl" : "{path}/temp/{asset_type}.ttl",
-			"-enable" : "false"
+			"-enable" : "false",
+			"-asset-name" : "{name}"
 		}	
 	}
 }

--- a/configs/process.json
+++ b/configs/process.json
@@ -50,16 +50,16 @@
 			"filename": "config_shacl_combiner.json"
 		},
 		{
-			"enable": true,
-			"filename": "config_wizard_caller.json"
-		},
-		{
 			"enable": false,
 			"filename": "config_llm_enricher.json",
 			"extensions": [
 				"xodr",
 				"xosc"
 			]
+		},
+		{
+			"enable": true,
+			"filename": "config_wizard_caller.json"
 		},
 		{
 			"enable": true,

--- a/llm_enricher/main.py
+++ b/llm_enricher/main.py
@@ -174,17 +174,68 @@ def enrich_single(
     with open(out_file, "w") as f:
         json.dump(enriched_metadata, f, indent=2, ensure_ascii=False)
 
+    # Write provenance sidecar for downstream consumers (e.g. wizard)
+    provenance = _build_provenance(
+        enrichment["fields"],
+        enrichment["confidence"],
+        asset_dir.name,
+        asset_type,
+    )
+    provenance_file = out_file.parent / f"{out_file.stem}_provenance.json"
+    with open(provenance_file, "w") as f:
+        json.dump(provenance, f, indent=2, ensure_ascii=False)
+
     logger.info(
-        "Enriched %d fields for %s → %s",
+        "Enriched %d fields for %s → %s (provenance → %s)",
         len(enrichment["fields"]),
         asset_dir.name,
         out_file,
+        provenance_file,
     )
 
     return {
         "enriched_fields": enrichment["fields"],
         "confidence": enrichment["confidence"],
         "output": str(out_file),
+    }
+
+
+def _build_provenance(
+    fields: dict,
+    confidence: dict[str, str],
+    asset_name: str,
+    asset_type: str,
+    *,
+    default_method: str = "rule-based-inference",
+    methods: dict[str, str] | None = None,
+) -> dict:
+    """Build a provenance sidecar describing which fields were enriched and how."""
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as pkg_version
+
+    try:
+        tool_version = pkg_version("sl-5-8-asset-tools")
+    except PackageNotFoundError:
+        tool_version = "0.0.0-dev"
+
+    methods = methods or {}
+    field_records = {}
+    for field_name, value in fields.items():
+        if value is None:
+            continue
+        field_records[field_name] = {
+            "method": methods.get(field_name, default_method),
+            "confidence": confidence.get(field_name, "medium"),
+        }
+
+    return {
+        "assetName": asset_name,
+        "assetType": asset_type,
+        "tool": {
+            "name": "sl-5-8-asset-tools/llm_enricher",
+            "version": tool_version,
+        },
+        "fields": field_records,
     }
 
 

--- a/utils/asset_registry.py
+++ b/utils/asset_registry.py
@@ -1,0 +1,167 @@
+"""Asset registry — cross-reference state shared between pipeline runs.
+
+After each pipeline run completes, the registry records the asset's CID,
+manifest path, and simulation-data file path.  Before a subsequent run
+injects ``hasReferencedArtifacts``, it can look up ``__*__`` placeholders
+and resolve them to real values from a previously-generated asset.
+
+The registry is stored as ``.asset_registry.json`` in the output directory
+so that batch and single-asset runs share the same state transparently.
+
+Registry schema::
+
+    {
+      "<filename_stem>": {
+        "hdmap": {
+          "cid": "bafkrei...",
+          "manifest_path": "MyRoad/manifest.json",
+          "sim_data_path": "simulation-data/MyRoad.xodr"
+        },
+        "scenario": {
+          "cid": "bafkrei...",
+          "manifest_path": "MyRoad_scenario/manifest.json",
+          "sim_data_path": "simulation-data/MyRoad.xosc"
+        }
+      }
+    }
+
+Placeholder mapping::
+
+    __OPENDRIVE_ASSET_CID__  → hdmap entry["cid"]
+    __OPENDRIVE_ASSET_PATH__ → hdmap entry["sim_data_path"]
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_FILENAME = ".asset_registry.json"
+
+# Maps placeholder tokens to registry entry keys.
+_PLACEHOLDER_MAP: dict[str, tuple[str, str]] = {
+    # (asset_type, entry_key)
+    "__OPENDRIVE_ASSET_CID__": ("hdmap", "cid"),
+    "__OPENDRIVE_ASSET_PATH__": ("hdmap", "sim_data_path"),
+}
+
+# Nested type: stem → asset_type → entry
+RegistryType = dict[str, dict[str, dict[str, str]]]
+
+
+def _registry_path(output_dir: Path) -> Path:
+    return output_dir / REGISTRY_FILENAME
+
+
+def load_registry(output_dir: Path) -> RegistryType:
+    """Load the registry from *output_dir*, returning an empty dict if absent."""
+    path = _registry_path(output_dir)
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to read asset registry %s: %s", path, exc)
+        return {}
+
+
+def save_registry(output_dir: Path, registry: RegistryType) -> None:
+    """Atomically write the registry to *output_dir*."""
+    path = _registry_path(output_dir)
+    payload = json.dumps(registry, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(payload, encoding="utf-8")
+        tmp.replace(path)
+    except OSError as exc:
+        logger.warning("Failed to write asset registry %s: %s", path, exc)
+        tmp.unlink(missing_ok=True)
+
+
+def register_asset(
+    output_dir: Path,
+    *,
+    stem: str,
+    asset_type: str,
+    cid: str,
+    manifest_path: str,
+    sim_data_path: str,
+) -> None:
+    """Record a completed asset in the registry."""
+    registry = load_registry(output_dir)
+    registry.setdefault(stem, {})[asset_type] = {
+        "cid": cid,
+        "manifest_path": manifest_path,
+        "sim_data_path": sim_data_path,
+    }
+    save_registry(output_dir, registry)
+    logger.debug("Registered asset %s (type=%s, cid=%s)", stem, asset_type, cid)
+
+
+def has_collision(output_dir: Path, stem: str, asset_type: str) -> bool:
+    """Return True if a different asset type already occupies *stem*."""
+    registry = load_registry(output_dir)
+    entry = registry.get(stem, {})
+    return bool(entry) and asset_type not in entry
+
+
+def resolve_placeholders(
+    refs: list[dict[str, Any]],
+    output_dir: Path,
+    *,
+    current_stem: str | None = None,
+) -> list[dict[str, Any]]:
+    """Resolve ``__*__`` placeholders in referenced-artifact link dicts.
+
+    Looks up the registry in *output_dir* and substitutes placeholder
+    values with actual CID / path values from previously-generated assets.
+
+    When *current_stem* is given, the resolver prefers a registry entry
+    whose stem matches (e.g. scenario ``Foo.xosc`` resolves against
+    hdmap ``Foo``).  Falls back to the first entry of the required type.
+
+    Returns the (mutated) *refs* list for convenience.
+    """
+    registry = load_registry(output_dir)
+    if not registry:
+        return refs
+
+    def _pick(asset_type: str) -> dict[str, str] | None:
+        # Prefer same-stem entry
+        if current_stem and current_stem in registry:
+            entry = registry[current_stem].get(asset_type)
+            if entry:
+                return entry
+        # Fall back to first entry of that type
+        for stem_entries in registry.values():
+            if asset_type in stem_entries:
+                return stem_entries[asset_type]
+        return None
+
+    for ref in refs:
+        meta = ref.get("hasFileMetadata", ref.get("manifest:hasFileMetadata", {}))
+
+        for field in ("filePath", "manifest:filePath"):
+            val = meta.get(field)
+            if isinstance(val, str) and val in _PLACEHOLDER_MAP:
+                asset_type, key = _PLACEHOLDER_MAP[val]
+                entry = _pick(asset_type)
+                if entry:
+                    meta[field] = entry[key]
+                    logger.info("Resolved %s → %s", val, meta[field])
+
+        for field in ("cid", "manifest:cid"):
+            val = meta.get(field)
+            if isinstance(val, str) and val in _PLACEHOLDER_MAP:
+                asset_type, key = _PLACEHOLDER_MAP[val]
+                entry = _pick(asset_type)
+                if entry:
+                    meta[field] = entry[key]
+                    logger.info("Resolved %s → %s", val, meta[field])
+
+    return refs

--- a/wizard_caller/api_client.py
+++ b/wizard_caller/api_client.py
@@ -118,12 +118,15 @@ def create_session(
     shacl_path: Path,
     jsonld_path: Path | None,
     output_path: Path,
+    provenance_path: Path | None = None,
+    asset_name: str | None = None,
     timeout: int = _TIMEOUT,
 ) -> None:
     """Create a wizard session — hand off files for browser-based editing.
 
     Calls ``POST /session`` with the SHACL file, optional JSON-LD prefill,
-    and the output path where the final JSON-LD should be written.
+    provenance sidecar, asset name, and the output path where the final
+    JSON-LD should be written.
 
     Raises:
         WizardAPIError: on HTTP error or connection failure.
@@ -136,7 +139,10 @@ def create_session(
                 "shaclFile": (shacl_path.name, shacl_f, "text/turtle"),
                 "outputPath": (None, str(output_path.resolve())),
             }
+            if asset_name:
+                files["assetName"] = (None, asset_name)
             jsonld_f = None
+            prov_f = None
             try:
                 if jsonld_path and jsonld_path.exists():
                     jsonld_f = open(jsonld_path, "rb")  # noqa: SIM115
@@ -145,12 +151,25 @@ def create_session(
                         jsonld_f,
                         "application/json",
                     )
+                if provenance_path and provenance_path.exists():
+                    prov_f = open(provenance_path, "rb")  # noqa: SIM115
+                    files["provenanceFile"] = (
+                        provenance_path.name,
+                        prov_f,
+                        "application/json",
+                    )
                 resp = requests.post(url, files=files, timeout=timeout)
             finally:
                 if jsonld_f:
                     jsonld_f.close()
+                if prov_f:
+                    prov_f.close()
     except requests.ConnectionError as exc:
         raise WizardAPIError(f"Cannot connect to Wizard API at {api_url}") from exc
+    except requests.Timeout as exc:
+        raise WizardAPIError(
+            f"Wizard API session creation timed out after {timeout}s"
+        ) from exc
     except OSError as exc:
         raise WizardAPIError(f"Cannot read input file: {exc}") from exc
 
@@ -193,6 +212,8 @@ def open_wizard_browser(
     shacl_path: Path | None = None,
     jsonld_path: Path | None = None,
     output_path: Path | None = None,
+    provenance_path: Path | None = None,
+    asset_name: str | None = None,
 ) -> bool:
     """Create a session, open the browser, and wait for user to export.
 
@@ -205,15 +226,24 @@ def open_wizard_browser(
 
     if shacl_path and output_path:
         logger.info("Creating wizard session...")
-        create_session(api_url, shacl_path, jsonld_path, output_path)
+        create_session(
+            api_url,
+            shacl_path,
+            jsonld_path,
+            output_path,
+            provenance_path=provenance_path,
+            asset_name=asset_name,
+        )
 
+    asset_label = f" for {asset_name}" if asset_name else ""
     logger.info("Opening browser at %s", fe_url)
     webbrowser.open(fe_url)
 
     logger.info(
-        "Waiting for you to complete the wizard in the browser...\n"
-        "  → Fill in the form fields and click 'Export JSON-LD' when done.\n"
-        "  → The pipeline will continue automatically."
+        "Waiting for you to complete the wizard%s in the browser...\n"
+        "  → Review pre-filled fields and click 'Export JSON-LD' when done.\n"
+        "  → The pipeline will continue automatically.",
+        asset_label,
     )
 
     return wait_for_export(api_url)

--- a/wizard_caller/main.py
+++ b/wizard_caller/main.py
@@ -54,6 +54,16 @@ def main():
             "Falls back to env var WIZARD_FRONTEND_URL."
         ),
     )
+    parser.add_argument(
+        "-asset-name",
+        default=None,
+        help="Name of the asset being processed (displayed in wizard header).",
+    )
+    parser.add_argument(
+        "-provenance",
+        default=None,
+        help="Path to provenance sidecar JSON from llm_enricher.",
+    )
     args = parser.parse_args()
 
     jsonld_path = Path(args.filename)
@@ -82,6 +92,22 @@ def main():
         args.api_url or os.environ.get("WIZARD_API_URL") or "http://localhost:3007"
     )
     frontend_url = args.frontend_url or os.environ.get("WIZARD_FRONTEND_URL")
+    provenance_path = Path(args.provenance) if args.provenance else None
+    asset_name = args.asset_name
+
+    # Auto-detect provenance sidecar if not explicitly provided.
+    # Check next to the input JSON-LD first (temp/), then next to the
+    # output path (metadata/) where llm_enricher writes its sidecar.
+    if provenance_path is None:
+        candidates = [
+            jsonld_path.parent / f"{jsonld_path.stem}_provenance.json",
+            output_path.parent / f"{output_path.stem}_provenance.json",
+        ]
+        for candidate in candidates:
+            if candidate.exists():
+                provenance_path = candidate
+                logger.info("Auto-detected provenance sidecar: %s", candidate)
+                break
 
     from wizard_caller.api_client import (
         WizardAPIError,
@@ -99,6 +125,8 @@ def main():
                 shacl_path=shacl_path,
                 jsonld_path=jsonld_path,
                 output_path=output_path,
+                provenance_path=provenance_path,
+                asset_name=asset_name,
             )
             if success:
                 logger.info("Wizard export complete → %s", output_path)


### PR DESCRIPTION
## Summary

Adds **provenance-aware wizard verification**, **batch processing**, and **cross-reference resolution** to the asset pipeline. Together these enable processing all example assets in one command (`make generate batch`), resolving inter-asset references automatically, and optionally reviewing metadata interactively (`make review`).

## Changes

### 1. Wizard Provenance Flow (`d2b4c10`, `878ba9e`)

Positions the sd-creation-wizard as the **human verification layer** after automated metadata extraction and LLM-based enrichment. The wizard displays provenance badges showing how each field was derived.

- **`configs/process.json`**: `llm_enricher` runs before `wizard_caller` so enriched metadata is available for review
- **`llm_enricher/main.py`**: `_build_provenance()` writes a `_provenance.json` sidecar with per-field method and confidence; narrowed bare except to `PackageNotFoundError`; made provenance method configurable
- **`wizard_caller/main.py`**: Added `-asset-name` and `-provenance` args; auto-detects provenance sidecar in both `temp/` and `metadata/` dirs
- **`wizard_caller/api_client.py`**: Added `requests.Timeout` handler in `create_session()`
- **`configs/config_wizard_caller.json`**: Added `-asset-name: "{name}"` placeholder

### 2. Batch Processing & Interactive Review (`2ca9c90`, `eca3874`)

- **`batch_runner.py`** (new): Orchestrator with `batch` and `review` subcommands
  - `batch`: discovers all `input_manifest.json` under a directory tree, sorts hdmap-first for dependency ordering, runs pipeline for each
  - `review`: enriches metadata → queues assets into wizard → detects changes → re-zips modified assets
- **`Makefile`**: Added `make generate batch`, `make review` targets with help text
- **`README.md`**: Documented batch processing, review mode, and validate-vs-review semantics

### sd-creation-wizard submodule (`eca3874`)

- **Session API** (`session.ts`): Queue endpoints — `POST /session/queue`, `GET /session/queue/status`, `POST /session/queue/next`, `POST /session/queue/prev`; plus provenance/asset-name fields on existing endpoints
- **WizardPage**: Queue progress bar, auto-advance on export, completion screen; provenance context provider, session auto-load
- **FieldWrapper**: Provenance badges (extracted/calculated/inferred/LLM/manual) with confidence indicators
- **ReviewStep**: Provenance summary table with color-coded methods
- **api-client.ts**: Queue types, `advanceQueue()`, fixed `exportToSession` payload

### 3. Asset Registry & Cross-Reference Resolution (`e793b99`)

- **`utils/asset_registry.py`** (new): Shared `.asset_registry.json` in output directory
  - Nested schema: `stem → asset_type → {cid, manifest_path, sim_data_path}`
  - `resolve_placeholders()`: stem-aware substitution of `__OPENDRIVE_ASSET_*__` tokens
  - `has_collision()`: detects when hdmap and scenario share the same filename stem
- **`asset_extraction/main.py`**: Computes asset_type early; checks registry for stem collisions (appends `_scenario` suffix when needed); resolves placeholders before ref injection; registers asset after zip creation
- **`Makefile`**: Simplified `make generate openscenario` — removed backup/resolve/restore dance (pipeline handles resolution natively); clears stale registry on batch runs

## Data Flow

```
input_manifest.json
  → meta_data_extractor → jsonLD_creator → shacl_combiner
  → llm_enricher (enriched JSON-LD + provenance sidecar)
  → wizard_caller (passes provenance + asset name to session API)
  → wizard UI (provenance badges, queue navigation)
  → user reviews & exports → jsonLD_validator
  → qualitychecker → xodr_routing_creator → asset_reducer
  → structure_creator → manifest.json
  → resolve cross-references from .asset_registry.json
  → create CID.zip → register asset in registry
```

## New Commands

```bash
make generate batch                    # Process all examples (hdmap-first ordering)
make generate batch INPUT_DIR=path/    # Process custom input directory
make review                            # Interactive metadata review via wizard
make review REVIEW_DIR=path/           # Review specific assets directory
```

## Testing

- `make generate batch`: **47/47 assets succeeded** ✓
- `make generate opendrive` + `openscenario`: backward compatible ✓
- Cross-references: **zero unresolved `__OPENDRIVE_ASSET_*__` placeholders** ✓
- Stem collisions: 22 `_scenario` suffixed dirs created correctly ✓
- CI: all 11 checks passed ✓

## Related

- Depends on PR #31 (llm_enricher) — ✅ merged
- Related to PR #75 (OMB AttributeProvenance ontology) — separate repo
- sd-creation-wizard changes pushed directly to main (project convention)