### PR TITLE
fix(metadata): normalize formatType, skip degenerate GeoJSON, round floats

### DIFF
--- a/llm_enricher/main.py
+++ b/llm_enricher/main.py
@@ -378,7 +378,41 @@ def _merge_enrichment(metadata: dict, enriched_fields: dict, prefix: str) -> dic
                 # For dict sections, write back (list items are mutated in-place)
                 domain_spec[section_key] = section
 
+    # Normalize legacy formatType ("ASAM OpenSCENARIO" → XML/DSL based on version)
+    _normalize_format_type(domain_spec, prefix)
+
     return result
+
+
+def _normalize_format_type(domain_spec: dict, prefix: str) -> None:
+    """Normalize legacy 'ASAM OpenSCENARIO' formatType to XML or DSL variant.
+
+    Since January 2024, ASAM split the standard into 'ASAM OpenSCENARIO XML'
+    (v1.x) and 'ASAM OpenSCENARIO DSL' (v2.x). Infers the correct suffix
+    from the version field when the generic name is found.
+    """
+    format_section = domain_spec.get(f"{prefix}:hasFormat")
+    if not isinstance(format_section, dict):
+        return
+
+    format_type = format_section.get("formatType", "")
+    if format_type != "ASAM OpenSCENARIO":
+        return
+
+    version = str(format_section.get("version", ""))
+    major = version.split(".")[0] if version else ""
+
+    if major.isdigit() and int(major) >= 2:
+        format_section["formatType"] = "ASAM OpenSCENARIO DSL"
+    else:
+        # Default to XML for v1.x or when version is unclear
+        format_section["formatType"] = "ASAM OpenSCENARIO XML"
+
+    logger.info(
+        "Normalized formatType: 'ASAM OpenSCENARIO' → '%s' (version %s)",
+        format_section["formatType"],
+        version or "unknown",
+    )
 
 
 def main():

--- a/meta_data_extractor/engine/transforms.py
+++ b/meta_data_extractor/engine/transforms.py
@@ -224,7 +224,7 @@ def sum_div_1000(data: Any, **kwargs) -> float:
     if not isinstance(data, list):
         data = [data] if data else []
     total = sum(float(v) for v in data if v is not None)
-    return total / 1000
+    return round(total / 1000, 6)
 
 
 @register("collect_custom_commands")

--- a/meta_data_extractor/xodr/extract_odr.py
+++ b/meta_data_extractor/xodr/extract_odr.py
@@ -137,17 +137,17 @@ def _build_georeference(data: dict) -> dict | None:
             lat_min, lon_min = convert_to_LatLon(x_min, y_min, geo_ref_cleaned)
             lat_max, lon_max = convert_to_LatLon(x_max, y_max, geo_ref_cleaned)
             projection_location_dict["georeference:hasBoundingBox"] = {
-                "georeference:xMin": str(lon_min),
-                "georeference:yMin": str(lat_min),
-                "georeference:xMax": str(lon_max),
-                "georeference:yMax": str(lat_max),
+                "georeference:xMin": f"{lon_min:.8f}",
+                "georeference:yMin": f"{lat_min:.8f}",
+                "georeference:xMax": f"{lon_max:.8f}",
+                "georeference:yMax": f"{lat_max:.8f}",
             }
 
             # Origin (0,0 in local coords)
             lat_origin, lon_origin = convert_to_LatLon(0.0, 0.0, geo_ref_cleaned)
             geodetic_dict["georeference:hasOrigin"] = {
-                "georeference:lat": str(lat_origin),
-                "georeference:lon": str(lon_origin),
+                "georeference:lat": f"{lat_origin:.8f}",
+                "georeference:lon": f"{lon_origin:.8f}",
             }
 
             # View point (center of bbox)
@@ -155,8 +155,8 @@ def _build_georeference(data: dict) -> dict | None:
             center_lon = (lon_min + lon_max) * 0.5
             get_adress_from_osm(projection_location_dict, center_lat, center_lon)
             geodetic_dict["georeference:hasViewPoint"] = {
-                "georeference:lat": str(center_lat),
-                "georeference:lon": str(center_lon),
+                "georeference:lat": f"{center_lat:.8f}",
+                "georeference:lon": f"{center_lon:.8f}",
             }
         except Exception:
             logger.warning("Could not convert georeference coordinates")

--- a/xodr_routing_creator/main.py
+++ b/xodr_routing_creator/main.py
@@ -57,9 +57,7 @@ def create_kml(elements: list, output_file: Path, isPolygon: bool):
 
 
 # create and write data as GeoJson elements
-def create_geojson(
-    elements: list, output_file: Path, isPolygon: bool, is_georeferenced: bool = True
-):
+def create_geojson(elements: list, output_file: Path, isPolygon: bool):
     features = []
     for element in elements:
         if isPolygon:
@@ -83,11 +81,6 @@ def create_geojson(
         features.append(feature)
 
     geojson = {"type": "FeatureCollection", "features": features}
-    if not is_georeferenced:
-        geojson["properties"] = {
-            "crs": "local",
-            "note": "Coordinates are in local meters (no georeference)",
-        }
 
     # write GeoJSON
     write_json(output_file, geojson, indentValue=2)
@@ -141,13 +134,11 @@ def main():
         # Reproject the coordinates
         transformed_lines = reproject(lines, offset, transformer_proj_to_wgs84)
     else:
-        logger.warning(
-            "No georeference/projection found in OpenDRIVE file. "
-            "GeoJSON output will use local coordinates (not WGS84)."
+        logger.info(
+            "Skipping GeoJSON output — file has no georeference. "
+            "Local-meter coordinates cannot produce valid WGS84 geometry."
         )
-        transformed_lines = reproject(lines, offset, None)
-
-    is_georeferenced = projection is not None
+        return
 
     # crate and write bounding box
     output_file_box = Path(args.box) if args.box else None
@@ -165,13 +156,13 @@ def main():
         boxes.append(coordinates)
         box_extension = output_file_box.suffix.lower()
         if box_extension == ".geojson":
-            create_geojson(boxes, output_file_box, True, is_georeferenced)
+            create_geojson(boxes, output_file_box, True)
         else:
             create_kml(boxes, output_file_box, True)
 
     # write line data
     if extension == ".geojson":
-        create_geojson(transformed_lines, output_file, False, is_georeferenced)
+        create_geojson(transformed_lines, output_file, False)
     else:
         create_kml(transformed_lines, output_file, False)
 


### PR DESCRIPTION
## Summary

Three metadata quality fixes bundled in one PR:

### 1. Format type normalization (`llm_enricher`)
Infers correct ASAM OpenSCENARIO suffix from version when legacy data only contains generic "ASAM OpenSCENARIO":
- v1.x → "ASAM OpenSCENARIO XML"
- v2.x → "ASAM OpenSCENARIO DSL"

### 2. Degenerate bbox.geojson (Issue #26 item 2)
Non-georeferenced OpenDRIVE files produced bbox/roadNetwork GeoJSON with all-zero latitudes (11 assets affected). Now returns early with an info log instead of writing invalid geometry.

### 3. Float precision noise (Issue #26 item 3)
- `sum_div_1000` rounds to 6 decimals (km to mm precision)
- Georeference coordinates formatted to 8 decimal places (~1mm WGS84)

### 4. Wizard submodule update
Pins sd-creation-wizard to include:
- 3-tier JSON-LD key matching (prefixed, bare local names, full URIs)
- Empty wizard step filtering for validation-only SHACL constraints

Closes #26