### PR TITLE
feat(init): add manifest generator for new users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ define check_dev_setup
 	fi
 endef
 
-.PHONY: all setup install lint format check validate generate clean wizard help
+.PHONY: all setup install lint format check validate generate init clean wizard help
 
 # Default target
 all: check
@@ -278,6 +278,19 @@ else
 	echo "[OK] $$dir pipeline complete"
 endif
 
+# ── Init manifest ─────────────────────────────────────────────────────
+
+init:
+	$(call check_dev_setup)
+	@if [ -z "$(INPUT_DIR)" ]; then \
+		echo "[ERR] INPUT_DIR is required."; \
+		echo "Usage:  make init INPUT_DIR=path/to/your/files"; \
+		exit 1; \
+	fi
+	@"$(PYTHON)" -m scripts.init_manifest "$(INPUT_DIR)" $(if $(findstring true,$(FORCE)),--force)
+	@echo "[OK] Created $(INPUT_DIR)/input_manifest.json"
+	@echo "     Edit it if needed, then run:  make generate INPUT_DIR=$(INPUT_DIR)"
+
 # ── Review (interactive metadata review) ─────────────────────────────
 
 REVIEW_DIR ?= $(ASSETS_DIR)
@@ -380,6 +393,10 @@ help:
 	@echo "  make check md                Lint Markdown files"
 	@echo ""
 	@echo "  make validate                Validate generated examples against SHACL"
+	@echo ""
+	@echo "  make init INPUT_DIR=<path>   Generate input_manifest.json from files in a directory"
+	@echo "  make init INPUT_DIR=<path> FORCE=true"
+	@echo "                               Overwrite existing manifest"
 	@echo ""
 	@echo "  make generate opendrive      Run OpenDRIVE example pipeline"
 	@echo "  make generate openscenario   Run OpenSCENARIO example pipeline"

--- a/README.md
+++ b/README.md
@@ -190,6 +190,26 @@ make generate opendrive
 
 ## Input Manifest
 
+### Generating a Manifest Automatically
+
+If you don't have an `input_manifest.json` yet, generate one from your files:
+
+```bash
+make init INPUT_DIR=path/to/my-asset
+```
+
+This scans the directory for simulation data (`.xodr`, `.xosc`, `.zip`, `.7z`),
+documentation, media, and license files, then writes an `input_manifest.json`
+ready for the pipeline.  Review and edit the generated file if needed, then run:
+
+```bash
+make generate INPUT_DIR=path/to/my-asset
+```
+
+Use `FORCE=true` to overwrite an existing manifest.
+
+### Manifest Format
+
 The pipeline accepts an `input_manifest.json` (JSON-LD) that describes the asset
 files, their categories and access roles.
 

--- a/scripts/init_manifest.py
+++ b/scripts/init_manifest.py
@@ -1,0 +1,243 @@
+"""Generate an ``input_manifest.json`` from the files in a directory.
+
+Scans a directory for simulation data, documentation, media, and license
+files, then writes a valid EVES-003 input manifest (JSON-LD) that the
+asset-extraction pipeline can consume directly.
+
+Usage::
+
+    python -m scripts.init_manifest path/to/my-asset
+    python -m scripts.init_manifest path/to/my-asset --access-role isPublic
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import mimetypes
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CONTEXT = [
+    "https://w3id.org/ascs-ev/envited-x/manifest/v5/",
+    "https://w3id.org/ascs-ev/envited-x/envited-x/v3/",
+]
+
+# ── File classification ──────────────────────────────────────────────
+
+_SIM_DATA_EXTENSIONS = {
+    ".xodr": "application/xml",
+    ".xosc": "application/xml",
+    ".zip": "application/zip",
+    ".7z": "application/x-7z-compressed",
+}
+
+_DOC_EXTENSIONS = {".pdf", ".txt", ".md", ".docx", ".html", ".rst"}
+_MEDIA_EXTENSIONS = {".jpg", ".jpeg", ".png", ".svg", ".gif", ".mp4", ".webm"}
+_LICENSE_NAMES = {"license", "license.txt", "license.md"}
+_LICENSE_MIME = "text/plain"
+
+_MIME_OVERRIDES = {
+    ".xodr": "application/xml",
+    ".xosc": "application/xml",
+    ".geojson": "application/geo+json",
+    ".jsonld": "application/ld+json",
+}
+
+
+def _guess_mime(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in _MIME_OVERRIDES:
+        return _MIME_OVERRIDES[ext]
+    mime, _ = mimetypes.guess_type(path.name)
+    return mime or "application/octet-stream"
+
+
+def _classify_file(path: Path) -> tuple[str, str] | None:
+    """Return (category, mimeType) for a file, or None to skip it."""
+    name_lower = path.name.lower()
+    ext = path.suffix.lower()
+
+    if name_lower in _LICENSE_NAMES:
+        return "license", _LICENSE_MIME
+
+    if name_lower == "input_manifest.json":
+        return None
+
+    if ext in _SIM_DATA_EXTENSIONS:
+        return "isSimulationData", _SIM_DATA_EXTENSIONS[ext]
+
+    if ext in _DOC_EXTENSIONS:
+        return "isDocumentation", _guess_mime(path)
+
+    if ext in _MEDIA_EXTENSIONS:
+        return "isMedia", _guess_mime(path)
+
+    # JSON companion files (e.g. statistic_3dModel.json, openlabel)
+    if ext == ".json":
+        return "isMedia", "application/json"
+
+    return None
+
+
+# ── Manifest generation ──────────────────────────────────────────────
+
+
+def scan_directory(input_dir: Path) -> list[dict[str, Any]]:
+    """Scan *input_dir* and return classified file entries.
+
+    Each entry is ``{"path": relative_name, "category": ..., "mime": ...}``.
+    Only top-level files are included (no recursion).
+    """
+    entries: list[dict[str, Any]] = []
+    for child in sorted(input_dir.iterdir()):
+        if child.is_dir() or child.name.startswith("."):
+            continue
+        result = _classify_file(child)
+        if result is None:
+            logger.debug("Skipping unrecognized file: %s", child.name)
+            continue
+        category, mime = result
+        entries.append({"path": child.name, "category": category, "mime": mime})
+    return entries
+
+
+def build_manifest(
+    entries: list[dict[str, Any]],
+    *,
+    access_role: str = "isOwner",
+) -> dict[str, Any]:
+    """Build an input_manifest.json dict from classified file entries."""
+    artifacts: list[dict] = []
+    license_link: dict | None = None
+
+    for entry in entries:
+        link: dict[str, Any] = {
+            "@type": "Link",
+            "hasCategory": f"envited-x:{entry['category']}",
+            "hasAccessRole": f"envited-x:{access_role}",
+            "hasFileMetadata": {
+                "@type": "FileMetadata",
+                "filePath": entry["path"],
+                "mimeType": entry["mime"],
+            },
+        }
+
+        if entry["category"] == "license":
+            link["hasCategory"] = "envited-x:isLicense"
+            link["hasAccessRole"] = "envited-x:isPublic"
+            license_link = link
+        else:
+            artifacts.append(link)
+
+    manifest: dict[str, Any] = {
+        "@context": CONTEXT,
+        "@id": "did:key:placeholder",
+        "@type": "envited-x:Manifest",
+    }
+
+    if artifacts:
+        manifest["hasArtifacts"] = artifacts
+
+    if license_link:
+        manifest["hasLicense"] = license_link
+
+    return manifest
+
+
+def generate_manifest(
+    input_dir: Path,
+    *,
+    output: Path | None = None,
+    access_role: str = "isOwner",
+    force: bool = False,
+) -> Path:
+    """Scan *input_dir*, build a manifest, and write it.
+
+    Returns the path of the written manifest file.
+    """
+    if not input_dir.is_dir():
+        raise FileNotFoundError(f"Not a directory: {input_dir}")
+
+    out_path = output or (input_dir / "input_manifest.json")
+    if out_path.exists() and not force:
+        raise FileExistsError(f"{out_path} already exists. Use --force to overwrite.")
+
+    entries = scan_directory(input_dir)
+
+    sim_data = [e for e in entries if e["category"] == "isSimulationData"]
+    if not sim_data:
+        raise ValueError(
+            f"No simulation data files found in {input_dir}. "
+            f"Expected: {', '.join(_SIM_DATA_EXTENSIONS)}"
+        )
+
+    manifest = build_manifest(entries, access_role=access_role)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(manifest, indent=4, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    logger.info("Wrote %s (%d artifact(s))", out_path, len(entries))
+    return out_path
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="init_manifest",
+        description=(
+            "Generate an input_manifest.json by scanning a directory for "
+            "simulation data, documentation, media, and license files."
+        ),
+    )
+    parser.add_argument(
+        "input_dir",
+        type=Path,
+        help="Directory containing asset files to package.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path (default: INPUT_DIR/input_manifest.json).",
+    )
+    parser.add_argument(
+        "--access-role",
+        default="isOwner",
+        choices=["isOwner", "isPublic", "isRegistered"],
+        help="Default access role for artifacts (default: isOwner).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing input_manifest.json.",
+    )
+
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)-7s %(message)s")
+
+    try:
+        path = generate_manifest(
+            args.input_dir,
+            output=args.output,
+            access_role=args.access_role,
+            force=args.force,
+        )
+        print(f"Created {path}")
+    except (FileNotFoundError, FileExistsError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_init_manifest.py
+++ b/scripts/tests/test_init_manifest.py
@@ -1,0 +1,153 @@
+"""Tests for scripts.init_manifest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.init_manifest import build_manifest, generate_manifest, scan_directory
+
+
+@pytest.fixture()
+def asset_dir(tmp_path: Path) -> Path:
+    """Create a minimal asset directory with an xodr, docs, and LICENSE."""
+    (tmp_path / "Town01.xodr").write_text("<OpenDRIVE/>")
+    (tmp_path / "docs.pdf").write_bytes(b"%PDF-1.4")
+    (tmp_path / "preview.png").write_bytes(b"\x89PNG")
+    (tmp_path / "LICENSE").write_text("MIT")
+    return tmp_path
+
+
+@pytest.fixture()
+def scenario_dir(tmp_path: Path) -> Path:
+    """Create a scenario asset directory."""
+    d = tmp_path / "scenario"
+    d.mkdir()
+    (d / "test.xosc").write_text("<OpenSCENARIO/>")
+    (d / "test.json").write_text("{}")
+    (d / "LICENSE.txt").write_text("Apache 2.0")
+    return d
+
+
+class TestScanDirectory:
+    def test_classifies_xodr(self, asset_dir: Path) -> None:
+        entries = scan_directory(asset_dir)
+        sim = [e for e in entries if e["category"] == "isSimulationData"]
+        assert len(sim) == 1
+        assert sim[0]["path"] == "Town01.xodr"
+        assert sim[0]["mime"] == "application/xml"
+
+    def test_classifies_license(self, asset_dir: Path) -> None:
+        entries = scan_directory(asset_dir)
+        lic = [e for e in entries if e["category"] == "license"]
+        assert len(lic) == 1
+        assert lic[0]["path"] == "LICENSE"
+        assert lic[0]["mime"] == "text/plain"
+
+    def test_classifies_docs(self, asset_dir: Path) -> None:
+        entries = scan_directory(asset_dir)
+        docs = [e for e in entries if e["category"] == "isDocumentation"]
+        assert len(docs) == 1
+        assert docs[0]["path"] == "docs.pdf"
+
+    def test_classifies_media(self, asset_dir: Path) -> None:
+        entries = scan_directory(asset_dir)
+        media = [e for e in entries if e["category"] == "isMedia"]
+        assert len(media) == 1
+        assert media[0]["path"] == "preview.png"
+
+    def test_skips_hidden_and_manifest(self, asset_dir: Path) -> None:
+        (asset_dir / ".hidden").write_text("")
+        (asset_dir / "input_manifest.json").write_text("{}")
+        entries = scan_directory(asset_dir)
+        names = [e["path"] for e in entries]
+        assert ".hidden" not in names
+        assert "input_manifest.json" not in names
+
+    def test_skips_subdirectories(self, asset_dir: Path) -> None:
+        (asset_dir / "subdir").mkdir()
+        (asset_dir / "subdir" / "nested.xodr").write_text("</>")
+        entries = scan_directory(asset_dir)
+        names = [e["path"] for e in entries]
+        assert "nested.xodr" not in names
+
+    def test_classifies_xosc(self, scenario_dir: Path) -> None:
+        entries = scan_directory(scenario_dir)
+        sim = [e for e in entries if e["category"] == "isSimulationData"]
+        assert len(sim) == 1
+        assert sim[0]["path"] == "test.xosc"
+
+    def test_json_companion_as_media(self, scenario_dir: Path) -> None:
+        entries = scan_directory(scenario_dir)
+        media = [e for e in entries if e["category"] == "isMedia"]
+        assert any(e["path"] == "test.json" for e in media)
+
+    def test_license_txt_variant(self, scenario_dir: Path) -> None:
+        entries = scan_directory(scenario_dir)
+        lic = [e for e in entries if e["category"] == "license"]
+        assert len(lic) == 1
+        assert lic[0]["path"] == "LICENSE.txt"
+
+    def test_3dmodel_extensions(self, tmp_path: Path) -> None:
+        (tmp_path / "model.zip").write_bytes(b"PK")
+        (tmp_path / "model.7z").write_bytes(b"7z")
+        entries = scan_directory(tmp_path)
+        assert len(entries) == 2
+        assert all(e["category"] == "isSimulationData" for e in entries)
+
+
+class TestBuildManifest:
+    def test_structure(self, asset_dir: Path) -> None:
+        entries = scan_directory(asset_dir)
+        manifest = build_manifest(entries)
+        assert manifest["@type"] == "envited-x:Manifest"
+        assert "@context" in manifest
+        assert "hasArtifacts" in manifest
+        assert "hasLicense" in manifest
+
+    def test_license_always_public(self, asset_dir: Path) -> None:
+        entries = scan_directory(asset_dir)
+        manifest = build_manifest(entries, access_role="isOwner")
+        assert manifest["hasLicense"]["hasAccessRole"] == "envited-x:isPublic"
+
+    def test_access_role_propagates(self, asset_dir: Path) -> None:
+        entries = scan_directory(asset_dir)
+        manifest = build_manifest(entries, access_role="isPublic")
+        for art in manifest["hasArtifacts"]:
+            assert art["hasAccessRole"] == "envited-x:isPublic"
+
+
+class TestGenerateManifest:
+    def test_creates_file(self, asset_dir: Path) -> None:
+        path = generate_manifest(asset_dir)
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["@type"] == "envited-x:Manifest"
+
+    def test_refuses_overwrite(self, asset_dir: Path) -> None:
+        generate_manifest(asset_dir)
+        with pytest.raises(FileExistsError, match="already exists"):
+            generate_manifest(asset_dir)
+
+    def test_force_overwrite(self, asset_dir: Path) -> None:
+        generate_manifest(asset_dir)
+        path = generate_manifest(asset_dir, force=True)
+        assert path.exists()
+
+    def test_error_no_sim_data(self, tmp_path: Path) -> None:
+        (tmp_path / "readme.txt").write_text("hello")
+        with pytest.raises(ValueError, match="No simulation data"):
+            generate_manifest(tmp_path)
+
+    def test_error_not_a_dir(self, tmp_path: Path) -> None:
+        fake = tmp_path / "nope"
+        with pytest.raises(FileNotFoundError, match="Not a directory"):
+            generate_manifest(fake)
+
+    def test_custom_output(self, asset_dir: Path) -> None:
+        out = asset_dir / "custom" / "manifest.json"
+        path = generate_manifest(asset_dir, output=out)
+        assert path == out
+        assert out.exists()


### PR DESCRIPTION
## Summary

Adds `make init INPUT_DIR=...` to scan a directory and auto-generate an `input_manifest.json` (JSON-LD) ready for the pipeline.

## Changes

- **`scripts/init_manifest.py`**: CLI tool that classifies files by extension:
  - `.xodr`/`.xosc` → simulation data, `.pdf`/`.txt` → documentation, images → media, LICENSE → license
  - Auto-detects MIME types, assigns access roles, generates proper JSON-LD structure
- **Makefile**: new `init` target with `INPUT_DIR` (required) and `FORCE=true` (optional)
- **README**: new "Generating a Manifest Automatically" section under Input Manifest
- **19 pytest tests**: file classification, manifest building, overwrite protection, error cases

## Usage

```bash
# Place your asset files in a directory
make init INPUT_DIR=path/to/my-asset

# Review the generated input_manifest.json, then run the pipeline
make generate INPUT_DIR=path/to/my-asset
```

## Motivation

Most users won't have a pre-written `input_manifest.json`. This lowers the entry barrier by auto-generating one from the files they already have.